### PR TITLE
Bump the GH-page deployment version

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
-      - uses: anleac/flutter-gh-pages@v0.3
+      - uses: anleac/flutter-gh-pages@v0.4
         with:
           baseHref: /defend_your_flame/
           webRenderer: both


### PR DESCRIPTION
Target the new release here: https://github.com/anleac/flutter-gh-pages/releases/tag/v0.4