### PR TITLE
Fix order rendering in entity manager, add ability to slam entity into the ground, other improvements

### DIFF
--- a/lib/constants/physics_constants.dart
+++ b/lib/constants/physics_constants.dart
@@ -5,6 +5,6 @@ class PhysicsConstants {
   static const double friction = 0.75;
   static final Vector2 gravity = Vector2(0, 1500.0);
 
-  static final Vector2 maxVelocity = Vector2(400, 2000);
+  static final Vector2 maxVelocity = Vector2(400, 2200);
   static final Vector2 negativeMaxVelocity = -maxVelocity;
 }

--- a/lib/constants/platform_constants.dart
+++ b/lib/constants/platform_constants.dart
@@ -1,6 +1,3 @@
 class PlatformConstants {
-  static const _webHtmlSuffix = 'htmlVersion';
-
-  static const webBaseUrl = 'defend_your_flame';
-  static const webHtmlUrl = '$webBaseUrl/$_webHtmlSuffix';
+  static const webHtmlSuffix = '/htmlVersion';
 }

--- a/lib/constants/versioning_constants.dart
+++ b/lib/constants/versioning_constants.dart
@@ -9,7 +9,7 @@ class VersioningConstants {
 
   static const _majorVersion = 0;
   static const _minorVersion = 2;
-  static const _patchVersion = 1;
+  static const _patchVersion = 2;
 
   static const _releaseVersion = ReleaseVersion.alpha;
 

--- a/lib/core/flame/components/entities/mobs/slime.dart
+++ b/lib/core/flame/components/entities/mobs/slime.dart
@@ -2,6 +2,8 @@ import 'package:defend_your_flame/core/flame/components/entities/animation_confi
 import 'package:defend_your_flame/core/flame/components/entities/walking_entity.dart';
 import 'package:defend_your_flame/core/flame/components/entities/walking_entity_config.dart';
 import 'package:flame/components.dart';
+import 'package:flame/effects.dart';
+import 'package:flutter/animation.dart';
 
 class Slime extends WalkingEntity {
   static final WalkingEntityConfig _slimeConfig = WalkingEntityConfig(
@@ -26,5 +28,25 @@ class Slime extends WalkingEntity {
     walkingForwardSpeed: 40,
   );
 
+  bool _removingAnimation = false;
+
   Slime({super.scaleModifier}) : super(entityConfig: _slimeConfig);
+
+  @override
+  void update(double dt) {
+    if (!super.isAlive && !_removingAnimation) {
+      _removingAnimation = true;
+      add(OpacityEffect.by(
+        -0.95,
+        EffectController(
+          duration: 2,
+          curve: Curves.decelerate,
+        ),
+      )..onComplete = () {
+          isVisible = false;
+        });
+    }
+
+    super.update(dt);
+  }
 }

--- a/lib/core/flame/components/hud/components/round_text.dart
+++ b/lib/core/flame/components/hud/components/round_text.dart
@@ -1,15 +1,11 @@
-import 'dart:ui';
-
 import 'package:defend_your_flame/core/flame/components/hud/level_hud.dart';
 import 'package:defend_your_flame/core/flame/main_game.dart';
 import 'package:flame/components.dart';
 
-class RoundText extends TextComponent with ParentIsA<LevelHud>, HasGameReference<MainGame> {
+class RoundText extends TextComponent with ParentIsA<LevelHud>, HasGameReference<MainGame>, HasVisibility {
   int _currentRound = 1;
 
   String get _roundText => game.appStrings.roundText(_currentRound);
-
-  bool _visible = false;
 
   @override
   void update(double dt) {
@@ -18,15 +14,8 @@ class RoundText extends TextComponent with ParentIsA<LevelHud>, HasGameReference
       text = _roundText;
     }
 
-    _visible = !parent.roundOver;
+    isVisible = !parent.roundOver;
 
     super.update(dt);
-  }
-
-  @override
-  void renderTree(Canvas canvas) {
-    if (_visible) {
-      super.renderTree(canvas);
-    }
   }
 }

--- a/lib/core/flame/components/hud/components/start_round_text.dart
+++ b/lib/core/flame/components/hud/components/start_round_text.dart
@@ -4,9 +4,8 @@ import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flutter/material.dart';
 
-class StartRound extends TextComponent with ParentIsA<LevelHud>, HasGameReference<MainGame>, TapCallbacks {
-  bool _visible = false;
-
+class StartRound extends TextComponent
+    with ParentIsA<LevelHud>, HasGameReference<MainGame>, TapCallbacks, HasVisibility {
   StartRound() : super(text: '', anchor: Anchor.center, scale: Vector2.all(1.2));
 
   @override
@@ -17,13 +16,13 @@ class StartRound extends TextComponent with ParentIsA<LevelHud>, HasGameReferenc
 
   @override
   void update(double dt) {
-    _visible = parent.roundOver;
+    isVisible = parent.roundOver;
     super.update(dt);
   }
 
   @override
   bool containsLocalPoint(Vector2 point) {
-    return _visible && super.containsLocalPoint(point);
+    return isVisible && super.containsLocalPoint(point);
   }
 
   @override
@@ -33,12 +32,5 @@ class StartRound extends TextComponent with ParentIsA<LevelHud>, HasGameReferenc
     // Only on the first round do we want the start game text.
     text = game.appStrings.startRound;
     parent.startRound();
-  }
-
-  @override
-  void renderTree(Canvas c) {
-    if (_visible) {
-      super.renderTree(c);
-    }
   }
 }

--- a/lib/core/flame/components/hud/components/start_round_text.dart
+++ b/lib/core/flame/components/hud/components/start_round_text.dart
@@ -2,7 +2,6 @@ import 'package:defend_your_flame/core/flame/components/hud/level_hud.dart';
 import 'package:defend_your_flame/core/flame/main_game.dart';
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
-import 'package:flutter/material.dart';
 
 class StartRound extends TextComponent
     with ParentIsA<LevelHud>, HasGameReference<MainGame>, TapCallbacks, HasVisibility {

--- a/lib/core/flame/components/hud/level_hud.dart
+++ b/lib/core/flame/components/hud/level_hud.dart
@@ -21,7 +21,7 @@ class LevelHud extends PositionComponent with ParentIsA<MainWorld> {
     ..anchor = Anchor.topCenter;
 
   late final StartRound _startRound = StartRound()
-    ..position = Vector2(parent.worldWidth / 2, parent.worldHeight / 2)
+    ..position = Vector2(parent.worldWidth / 2, parent.worldHeight / 4)
     ..anchor = Anchor.center;
 
   int get currentRound => parent.currentRound;

--- a/lib/core/flame/managers/entity_manager.dart
+++ b/lib/core/flame/managers/entity_manager.dart
@@ -1,3 +1,6 @@
+import 'dart:collection';
+import 'dart:ui';
+
 import 'package:defend_your_flame/core/flame/components/entities/mobs/skeleton.dart';
 import 'package:defend_your_flame/core/flame/components/entities/mobs/slime.dart';
 import 'package:defend_your_flame/core/flame/components/entities/walking_entity.dart';
@@ -7,6 +10,10 @@ import 'package:defend_your_flame/helpers/misc_helper.dart';
 import 'package:flame/components.dart';
 
 class EntityManager extends Component with ParentIsA<MainWorld> {
+  // Used to keep a weak reference to the entities, based on their Y position, so we can render them in the correct order.
+  // Using this datastructure as it supports O(log n) for insertion and deletion, and O(n) for iteration.
+  final SplayTreeMap<int, WalkingEntity> _entities = SplayTreeMap();
+
   bool _spawning = false;
   int _secondsToSpawnOver = 0;
   int _remainingEntitiesToSpawn = 0;
@@ -23,8 +30,12 @@ class EntityManager extends Component with ParentIsA<MainWorld> {
     _timeCounter = 0;
     _secondsToSpawnOver = 0;
 
+    _entities.clear();
+
     for (var element in children) {
-      if (element is WalkingEntity) element.removeFromParent();
+      if (element is WalkingEntity) {
+        element.removeFromParent();
+      }
     }
   }
 
@@ -62,6 +73,17 @@ class EntityManager extends Component with ParentIsA<MainWorld> {
     super.update(dt);
   }
 
+  @override
+  void renderTree(Canvas canvas) {
+    // Explicitly _not_ calling super, as we want to render the entities in the correct order
+    // Iterating over the splay map will give us the entities in the correct order, ordered in ascending Y position
+    for (var element in _entities.values) {
+      element.renderTree(canvas);
+    }
+
+    // super.renderTree(canvas);
+  }
+
   void spawnEntity() {
     var entity = MiscHelper.randomChance(chance: 80)
         ? Skeleton(scaleModifier: MiscHelper.randomDouble(minValue: 1, maxValue: 1.5))
@@ -73,6 +95,12 @@ class EntityManager extends Component with ParentIsA<MainWorld> {
     );
 
     entity.position = startPosition;
+    _addEntity(entity);
+  }
+
+  // Wrappers so we can track based on the position of the entity, to render them in the correct order
+  _addEntity(WalkingEntity entity) {
+    _entities[entity.position.y.toInt() + entity.scaledSize.y.toInt()] = entity;
     add(entity);
   }
 }

--- a/lib/core/flame/managers/entity_manager.dart
+++ b/lib/core/flame/managers/entity_manager.dart
@@ -12,7 +12,7 @@ import 'package:flame/components.dart';
 class EntityManager extends Component with ParentIsA<MainWorld> {
   // Used to keep a weak reference to the entities, based on their Y position, so we can render them in the correct order.
   // Using this datastructure as it supports O(log n) for insertion and deletion, and O(n) for iteration.
-  final SplayTreeMap<int, WalkingEntity> _entities = SplayTreeMap();
+  final SplayTreeMap<int, List<WalkingEntity>> _entities = SplayTreeMap();
 
   bool _spawning = false;
   int _secondsToSpawnOver = 0;
@@ -77,8 +77,10 @@ class EntityManager extends Component with ParentIsA<MainWorld> {
   void renderTree(Canvas canvas) {
     // Explicitly _not_ calling super, as we want to render the entities in the correct order
     // Iterating over the splay map will give us the entities in the correct order, ordered in ascending Y position
-    for (var element in _entities.values) {
-      element.renderTree(canvas);
+    for (var entitiesAtYPosition in _entities.values) {
+      for (var entity in entitiesAtYPosition) {
+        entity.renderTree(canvas);
+      }
     }
 
     // super.renderTree(canvas);
@@ -100,7 +102,12 @@ class EntityManager extends Component with ParentIsA<MainWorld> {
 
   // Wrappers so we can track based on the position of the entity, to render them in the correct order
   _addEntity(WalkingEntity entity) {
-    _entities[entity.position.y.toInt() + entity.scaledSize.y.toInt()] = entity;
+    var key = entity.position.y.toInt() + entity.scaledSize.y.toInt();
+    if (!_entities.containsKey(key)) {
+      _entities[key] = [];
+    }
+
+    _entities[key]!.add(entity);
     add(entity);
   }
 }

--- a/lib/helpers/platform_helper.dart
+++ b/lib/helpers/platform_helper.dart
@@ -61,13 +61,13 @@ class PlatformHelper {
   }
 
   static Widget webRedirectFooter() {
-    if (!Uri.base.toString().contains(PlatformConstants.webHtmlUrl)) {
+    if (!Uri.base.toString().contains(PlatformConstants.webHtmlSuffix)) {
       return Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           const Text("If you're noticing poor performance, try this link: "),
           TextButton(
-            onPressed: () => launchUrl(Uri.parse(PlatformConstants.webHtmlUrl)),
+            onPressed: () => launchUrl(Uri.parse(PlatformConstants.webHtmlSuffix)),
             child: const Text('HTML version'),
           ),
         ],
@@ -79,7 +79,11 @@ class PlatformHelper {
       children: [
         const Text("Try the higher graphic version: "),
         TextButton(
-          onPressed: () => launchUrl(Uri.parse(PlatformConstants.webBaseUrl)),
+          onPressed: () {
+            var baseUrl = Uri.base.toString();
+            var newUrl = baseUrl.replaceAll(PlatformConstants.webHtmlSuffix, '');
+            launchUrl(Uri.parse(newUrl));
+          },
           child: const Text('CanvasKit version'),
         ),
       ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: defend_your_flame
 description: Defend your castles flame from the enemy
 publish_to: 'none'
-version: 0.1.0+1
+version: 0.2.2+3
 
 environment:
   sdk: '>=3.1.2 <4.0.0'


### PR DESCRIPTION
Lots of quality of life improvements here being:
- Overhauled and added cool, and efficient, management for render ordering in entity manager using a SplayTree (which uses BST underlying):
- This fixes https://github.com/anleac/defend_your_flame/issues/14

<img width="648" alt="Showing correct ordering of rendered sprites" src="https://github.com/anleac/defend_your_flame/assets/13091188/011b3a97-8147-47b9-8137-3ddd80122bc7">
   
- Small scaling improvements based on screensize
- Small fixes to links
- Fix to making it unable to pick up a dead skeleton
- **New functionality**: Add ability to kill an entity by throwing into the ground
- Overhauled the drag velocity logic and made it scale better.   
