### PR TITLE
Small font fixes

### DIFF
--- a/lib/constants/versioning_constants.dart
+++ b/lib/constants/versioning_constants.dart
@@ -9,7 +9,7 @@ class VersioningConstants {
 
   static const _majorVersion = 0;
   static const _minorVersion = 3;
-  static const _patchVersion = 1;
+  static const _patchVersion = 2;
 
   static const _releaseVersion = ReleaseVersion.alpha;
 

--- a/lib/core/flame/components/hud/components/start_round_button.dart
+++ b/lib/core/flame/components/hud/components/start_round_button.dart
@@ -12,7 +12,6 @@ class StartRoundButton extends TextBoxComponent
           text: '',
           anchor: Anchor.center,
           textRenderer: TextManager.smallHeaderRenderer,
-          boxConfig: TextBoxConfig(timePerChar: 0.08),
         );
 
   @override

--- a/lib/states/state_manager.dart
+++ b/lib/states/state_manager.dart
@@ -1,6 +1,5 @@
 import 'package:defend_your_flame/constants/translations/app_strings.dart';
 import 'package:defend_your_flame/core/flame/game_provider.dart';
-import 'package:defend_your_flame/core/flame/managers/text_manager.dart';
 import 'package:defend_your_flame/helpers/platform_helper.dart';
 import 'package:defend_your_flame/widgets/background.dart';
 import 'package:flame/game.dart';
@@ -29,7 +28,6 @@ class _StateManagerState extends State<StateManager> with WidgetsBindingObserver
         ],
         supportedLocales: AppStrings.supportedLocales.map((e) => Locale(e)),
         initialRoute: '/',
-        theme: ThemeData(fontFamily: TextManager.defaultFontFamily),
         routes: {
           '/': (context) {
             var game = GameProvider.of(context).game;


### PR DESCRIPTION
This includes:
- Undoing the writing character timer for the start button, this appears to not render at all in HTML versioning
- Undo using the custom font for _all_ flutter based widgets, as this looks poor on the "try the HTML version" text