### PR TITLE
Small fix to the round text not showing on the first round

### DIFF
--- a/lib/constants/versioning_constants.dart
+++ b/lib/constants/versioning_constants.dart
@@ -9,7 +9,7 @@ class VersioningConstants {
 
   static const _majorVersion = 0;
   static const _minorVersion = 6;
-  static const _patchVersion = 0;
+  static const _patchVersion = 1;
 
   static const _releaseVersion = ReleaseVersion.alpha;
 

--- a/lib/core/flame/components/hud/text/round_text.dart
+++ b/lib/core/flame/components/hud/text/round_text.dart
@@ -4,7 +4,7 @@ import 'package:defend_your_flame/core/flame/worlds/main_world.dart';
 import 'package:flame/components.dart';
 
 class RoundText extends TextComponent with HasWorldReference<MainWorld>, HasGameReference<MainGame> {
-  int _currentRound = 1;
+  int _currentRound = 0;
 
   String get _roundText => game.appStrings.roundText(_currentRound);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: defend_your_flame
 description: Defend your castles flame from the enemy
 publish_to: 'none'
-version: 0.6.0+1 # +1 since we haven't actually published this yet
+version: 0.6.1+1 # +1 since we haven't actually published this yet
 
 environment:
   sdk: '>=3.1.2 <4.0.0'


### PR DESCRIPTION
This fixes the `Round 1` text now showing on the first round.