### PR TITLE
More polishes to drag physics, and adding safety timeouts, removing TimestepFaker

### DIFF
--- a/lib/constants/versioning_constants.dart
+++ b/lib/constants/versioning_constants.dart
@@ -9,7 +9,7 @@ class VersioningConstants {
 
   static const _majorVersion = 0;
   static const _minorVersion = 8;
-  static const _patchVersion = 2;
+  static const _patchVersion = 3;
 
   static const _releaseVersion = ReleaseVersion.alpha;
 

--- a/lib/core/flame/components/entities/draggable_entity.dart
+++ b/lib/core/flame/components/entities/draggable_entity.dart
@@ -12,13 +12,17 @@ import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 
 class DraggableEntity extends Entity with DragCallbacks {
+  static const double dragTimeoutInMilliseconds = 4000;
+
   late final double _pickupHeight;
 
   Vector2 _fallVelocity = Vector2.zero();
   bool _beingDragged = false;
 
   Vector2 _dragVelocity = Vector2.zero();
-  int _timeSinceLastDragEvent = 0;
+
+  double _stuckTimerInMilliseconds = 0;
+  int _timeSinceLastDragEventInMicroseconds = 0;
   double _totalDragDistance = 0;
 
   DraggableEntity({required super.entityConfig, super.scaleModifier});
@@ -53,8 +57,18 @@ class DraggableEntity extends Entity with DragCallbacks {
   @override
   void update(double dt) {
     _dragCalculation(dt);
+    _checkDragStuckLogic(dt);
 
     super.update(dt);
+  }
+
+  void _checkDragStuckLogic(double dt) {
+    if (_beingDragged) {
+      _stuckTimerInMilliseconds += dt;
+      if (_stuckTimerInMilliseconds > dragTimeoutInMilliseconds) {
+        stopDragging();
+      }
+    }
   }
 
   void _dragCalculation(double dt) {
@@ -85,7 +99,7 @@ class DraggableEntity extends Entity with DragCallbacks {
     _dragVelocity.x = influence * newVelocity.x + (1 - influence) * _dragVelocity.x;
     _dragVelocity.y = influence * newVelocity.y + (1 - influence) * _dragVelocity.y;
 
-    _fallVelocity = _dragVelocity / 2;
+    _fallVelocity = _dragVelocity / 1.6;
   }
 
   @override
@@ -96,8 +110,9 @@ class DraggableEntity extends Entity with DragCallbacks {
       return;
     }
 
-    var timeSinceLastDragEvent = event.timestamp.inMicroseconds - _timeSinceLastDragEvent;
-    _timeSinceLastDragEvent = event.timestamp.inMicroseconds;
+    var timeSinceLastDragEvent = event.timestamp.inMicroseconds - _timeSinceLastDragEventInMicroseconds;
+    _timeSinceLastDragEventInMicroseconds = event.timestamp.inMicroseconds;
+    _stuckTimerInMilliseconds = 0;
 
     var dragDistance = (event.canvasDelta / game.windowScale) * entityConfig.dragResistance;
 
@@ -136,7 +151,8 @@ class DraggableEntity extends Entity with DragCallbacks {
     _beingDragged = true;
     _totalDragDistance = 0;
     _dragVelocity = Vector2.zero();
-    _timeSinceLastDragEvent = 0;
+    _timeSinceLastDragEventInMicroseconds = 0;
+    _stuckTimerInMilliseconds = 0;
     current = EntityState.dragged;
   }
 

--- a/lib/core/flame/components/entities/draggable_entity.dart
+++ b/lib/core/flame/components/entities/draggable_entity.dart
@@ -12,7 +12,7 @@ import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 
 class DraggableEntity extends Entity with DragCallbacks {
-  static const double dragTimeoutInMilliseconds = 4000;
+  static const double dragTimeoutInSeconds = 3.5;
 
   late final double _pickupHeight;
 
@@ -65,7 +65,7 @@ class DraggableEntity extends Entity with DragCallbacks {
   void _checkDragStuckLogic(double dt) {
     if (_beingDragged) {
       _stuckTimerInMilliseconds += dt;
-      if (_stuckTimerInMilliseconds > dragTimeoutInMilliseconds) {
+      if (_stuckTimerInMilliseconds > dragTimeoutInSeconds) {
         stopDragging();
       }
     }

--- a/lib/core/flame/components/entities/entity.dart
+++ b/lib/core/flame/components/entities/entity.dart
@@ -10,7 +10,6 @@ import 'package:defend_your_flame/core/flame/managers/sprite_manager.dart';
 import 'package:defend_your_flame/core/flame/worlds/main_world.dart';
 import 'package:defend_your_flame/helpers/debug/debug_helper.dart';
 import 'package:defend_your_flame/helpers/physics_helper.dart';
-import 'package:defend_your_flame/helpers/timestep/debug/timestep_faker.dart';
 import 'package:defend_your_flame/helpers/timestep/timestep_helper.dart';
 import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
@@ -109,15 +108,12 @@ class Entity extends SpriteAnimationGroupComponent<EntityState>
 
   @override
   void update(double dt) {
-    var fakeTimestep = game.findByKeyName<TimestepFaker>(TimestepFaker.componentKey);
-
-    if (fakeTimestep != null) {
-      fakeTimestep.updateWithFakeTimestep(dt, _updateMovement);
-    } else {
-      _updateMovement(dt);
-    }
-
     super.update(dt);
+
+    _attackingLogic(dt);
+    _logicCalculation(dt);
+    fallingCalculation(dt);
+    _applyBoundingConstraints(dt);
   }
 
   @override
@@ -164,13 +160,6 @@ class Entity extends SpriteAnimationGroupComponent<EntityState>
   // Intended to be overridden by subclasses
   Vector2? attackEffectPosition() => null;
 
-  void _updateMovement(double dt) {
-    _attackingLogic(dt);
-    _logicCalculation(dt);
-    fallingCalculation(dt);
-    _applyBoundingConstraints(dt);
-  }
-
   void _attackingLogic(double dt) {
     if (current == EntityState.attacking) {
       // Special case where the game has ended.
@@ -207,6 +196,11 @@ class Entity extends SpriteAnimationGroupComponent<EntityState>
     if (position.x > world.worldWidth + BoundingConstants.maxXCoordinateOffScreen) {
       teleportToStart();
     }
+  }
+
+  void _checkStuckLogic() {
+    // There are a few cases I've observed so far where the entity can get stuck.
+    // 1. If the entity is dragged and then the game is paused, the entity will be stuck in the dragged state.
   }
 
   void _logicCalculation(double dt) {

--- a/lib/core/flame/components/entities/entity_config.dart
+++ b/lib/core/flame/components/entities/entity_config.dart
@@ -35,7 +35,6 @@ class EntityConfig {
   final int damageOnAttack;
   final int goldOnKill;
 
-  final bool canBeDragged;
   final double dragResistance;
 
   EntityConfig({
@@ -57,7 +56,6 @@ class EntityConfig {
     required this.walkingForwardSpeed,
     required this.damageOnAttack,
     required this.goldOnKill,
-    this.canBeDragged = true,
     this.dragResistance = 1.0,
   });
 }

--- a/lib/core/flame/components/entities/mobs/mage.dart
+++ b/lib/core/flame/components/entities/mobs/mage.dart
@@ -30,7 +30,6 @@ class Mage extends FlyingEntity {
     walkingForwardSpeed: 40,
     damageOnAttack: 0,
     goldOnKill: 15,
-    canBeDragged: false,
   );
 
   Mage({super.scaleModifier, super.extraXBoundaryOffset}) : super(entityConfig: _mageConfig);

--- a/lib/core/flame/components/entities/mobs/skeleton.dart
+++ b/lib/core/flame/components/entities/mobs/skeleton.dart
@@ -18,6 +18,7 @@ class Skeleton extends DraggableEntity {
     damageOnAttack: 8,
     goldOnKill: 5,
     walkingForwardSpeed: 27,
+    dragResistance: 0.9,
     collisionAnchor: Anchor.bottomLeft,
   );
 

--- a/lib/core/flame/components/entities/mobs/strong_skeleton.dart
+++ b/lib/core/flame/components/entities/mobs/strong_skeleton.dart
@@ -21,7 +21,7 @@ class StrongSkeleton extends DraggableEntity {
     walkingForwardSpeed: 19,
     // Let him survive two falls
     totalHealth: DamageConstants.fallDamage * 2,
-    dragResistance: 0.4,
+    dragResistance: 0.48,
   );
 
   StrongSkeleton({super.scaleModifier}) : super(entityConfig: _strongSkeletonConfig);

--- a/lib/core/flame/main_game.dart
+++ b/lib/core/flame/main_game.dart
@@ -31,10 +31,10 @@ class MainGame extends FlameGame {
   Future<void> onLoad() async {
     await SpriteManager.init();
 
-    add(TimestepFaker(
+    /*add(TimestepFaker(
       useFakeTimestep: DebugConstants.useFakeTimestep,
       fakeFps: DebugConstants.fakeFps,
-    ));
+    ));*/
 
     return super.onLoad();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: defend_your_flame
 description: Defend your castles flame from the enemy
 publish_to: 'none'
-version: 0.8.2+1 # +1 since we haven't actually published this yet
+version: 0.8.3+1 # +1 since we haven't actually published this yet
 
 environment:
   sdk: '>=3.1.2 <4.0.0'


### PR DESCRIPTION
This PR adds the following:
- More tweaks to the drag physics
- Bump to 0.8.3a
- Add safety mechanics for entities being in a stuck drag state, or off the right of the screen
- Remove the entities being wrapped in timestep faker, this is not currently needed