### PR TITLE
Small updates, work on the shop and wall upgrades.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.9.1 alpha - 28th April, 2024
+
+### New Features
+- Add concept of defense to a wall, which removes damage 1:1
+   - Gave the stone wall upgrade a defense of 1 (wood has 0)
+
+### Bug Fixes
+- N/A
+
+### Improvements
+- Scaled the spawning logic better to prefer mages later on, and strong skeletons more in the early rounds
+- Nerfed the mage damage
+- Added a better description to the stone wall upgrade
+
 ## 0.9.0 alpha - 28th April, 2024
 
 ### New Features

--- a/lib/constants/parallax_constants.dart
+++ b/lib/constants/parallax_constants.dart
@@ -1,4 +1,4 @@
 class ParallaxConstants {
   // How much we shift horizontally to the right as a fraction of moving down
-  static const horizontalDisplacementFactor = 1 / 12;
+  static const horizontalDisplacementFactor = 1 / 14;
 }

--- a/lib/constants/versioning_constants.dart
+++ b/lib/constants/versioning_constants.dart
@@ -8,7 +8,7 @@ class VersioningConstants {
   static final String version = _getVersion();
 
   static const _majorVersion = 0;
-  static const _minorVersion = 9;
+  static const _minorVersion = 10;
   static const _patchVersion = 0;
 
   static const _releaseVersion = ReleaseVersion.alpha;

--- a/lib/constants/versioning_constants.dart
+++ b/lib/constants/versioning_constants.dart
@@ -8,8 +8,8 @@ class VersioningConstants {
   static final String version = _getVersion();
 
   static const _majorVersion = 0;
-  static const _minorVersion = 10;
-  static const _patchVersion = 0;
+  static const _minorVersion = 9;
+  static const _patchVersion = 1;
 
   static const _releaseVersion = ReleaseVersion.alpha;
 

--- a/lib/core/flame/components/entities/disappear_on_death.dart
+++ b/lib/core/flame/components/entities/disappear_on_death.dart
@@ -5,6 +5,13 @@ import 'package:flutter/animation.dart';
 mixin DisappearOnDeath on Entity {
   bool _removingAnimation = false;
 
+  // The speed at which the entity will disappear when it dies, higher values will make it disappear faster.
+  double _disappearSpeedFactor = 1;
+
+  void setDisappearSpeedFactor(double factor) {
+    _disappearSpeedFactor = factor;
+  }
+
   @override
   void update(double dt) {
     if (!super.isAlive && !_removingAnimation) {
@@ -12,7 +19,7 @@ mixin DisappearOnDeath on Entity {
       add(OpacityEffect.by(
         -0.95,
         EffectController(
-          duration: 2,
+          duration: 2 / _disappearSpeedFactor,
           curve: Curves.decelerate,
         ),
       )..onComplete = () {

--- a/lib/core/flame/components/entities/mobs/mage.dart
+++ b/lib/core/flame/components/entities/mobs/mage.dart
@@ -30,7 +30,7 @@ class Mage extends FlyingEntity with DisappearOnDeath {
       frames: 8,
     ),
     walkingForwardSpeed: 34,
-    damageOnAttack: 0,
+    damageOnAttack: 12,
     goldOnKill: 15,
     totalHealth: DamageConstants.fallDamage * 4,
   );
@@ -47,7 +47,9 @@ class Mage extends FlyingEntity with DisappearOnDeath {
   late final RectangleHitbox _hitbox =
       EntityHelper.createRectangleHitbox(size: Vector2(36, 50), anchor: Anchor.topCenter, position: Vector2(80, 67));
 
-  Mage({super.scaleModifier}) : super(flyingEntityConfig: _mageConfig);
+  Mage({super.scaleModifier}) : super(flyingEntityConfig: _mageConfig) {
+    setDisappearSpeedFactor(2);
+  }
 
   @override
   List<ShapeHitbox> addHitboxes() {
@@ -69,7 +71,9 @@ class Mage extends FlyingEntity with DisappearOnDeath {
         _hitbox.absoluteTopLeftPosition + Vector2(_hitbox.width, 0) + (Vector2(8, -22) * scaleModifier);
 
     world.projectileManager.addProjectile(CurvingMagicProjectile(
-        initialPosition: attackPosition, targetPosition: world.playerManager.playerBase.wall.absoluteCenter));
+        initialPosition: attackPosition,
+        targetPosition: world.playerManager.playerBase.wall.absoluteCenter,
+        damage: _baseEntityConfig.damageOnAttack));
   }
 
   static Mage spawn({required double skyHeight}) {

--- a/lib/core/flame/components/masonry/walls/wall.dart
+++ b/lib/core/flame/components/masonry/walls/wall.dart
@@ -1,95 +1,50 @@
 import 'package:defend_your_flame/constants/debug_constants.dart';
 import 'package:defend_your_flame/constants/misc_constants.dart';
-import 'package:defend_your_flame/constants/parallax_constants.dart';
 import 'package:defend_your_flame/core/flame/components/masonry/walls/wall_helper.dart';
+import 'package:defend_your_flame/core/flame/components/masonry/walls/wall_renderer.dart';
 import 'package:defend_your_flame/core/flame/components/masonry/walls/wall_type.dart';
-import 'package:defend_your_flame/core/flame/managers/sprite_manager.dart';
 import 'package:defend_your_flame/core/flame/worlds/main_world.dart';
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
-import 'package:flame/image_composition.dart';
-import 'package:flutter/material.dart';
 
-class Wall extends PositionComponent with HasVisibility, HasWorldReference<MainWorld>, Snapshot {
-  static const double verticalDiffPerRender = 30;
-  double _horizontalRange = 0;
-  double _verticalRange = 0;
-  double _verticalRenders = 0;
-  double _horizontalDiffPerRender = 0;
-
-  late final double verticalRange;
-  late Sprite _wallSprite;
+class Wall extends PositionComponent with HasVisibility, HasWorldReference<MainWorld> {
+  late final WallRenderer _wallRenderer = WallRenderer(verticalRange: verticalRange)..size = size;
+  final double verticalRange;
 
   WallType _wallType = WallType.wood;
   late int _totalHealth = WallHelper.getDefaultTotalHealth(_wallType);
   int _health = 100;
 
   PolygonHitbox? _hitbox;
-  List<Vector2> _wallCornerPoints = [];
 
   WallType get wallType => _wallType;
   int get health => _health < 0 ? 0 : _health;
   int get totalHealth => _totalHealth;
 
-  List<Vector2> get wallCornerPoints => _wallCornerPoints;
   Vector2 get wallCenter => center;
 
   Wall({required this.verticalRange}) : super(size: Vector2(156, 398)) {
     scale = WallHelper.getScale(_wallType);
-    renderSnapshot = true;
   }
 
   @override
   void onLoad() {
     super.onLoad();
+    add(_wallRenderer);
+
     updateWallType(_wallType, firstLoad: true);
-  }
-
-  _updateRenderValues() {
-    _verticalRange = verticalRange / scale.y;
-    _verticalRenders = (_verticalRange / verticalDiffPerRender).ceilToDouble();
-
-    _horizontalRange = _verticalRange * ParallaxConstants.horizontalDisplacementFactor;
-    _horizontalDiffPerRender = _horizontalRange / _verticalRenders;
   }
 
   _clearAndAddHitbox() {
     _hitbox?.removeFromParent();
-
-    _updateRenderValues();
-    _wallCornerPoints.clear();
-    _wallCornerPoints.addAll([
-      Vector2(0, -size.y),
-      Vector2(size.x, -size.y),
-      Vector2(size.x + _horizontalRange, _verticalRange),
-      Vector2(_horizontalRange, _verticalRange),
-    ]);
+    _wallRenderer.updateWallRenderValues();
 
     // TODO post-beta release check performance of isSolid.
     add(
-      _hitbox = PolygonHitbox(_wallCornerPoints, isSolid: true)
+      _hitbox = PolygonHitbox(_wallRenderer.wallCornerPoints, isSolid: true)
         ..renderShape = DebugConstants.drawEntityCollisionBoxes
         ..paint = DebugConstants.transparentPaint,
     );
-  }
-
-  @override
-  void render(Canvas canvas) {
-    super.render(canvas);
-
-    double runningX = 0;
-    double runninyY = 0;
-    for (int i = 0; i < _verticalRenders; i++) {
-      _wallSprite.render(
-        canvas,
-        position: Vector2(runningX, runninyY - size.y),
-        size: size,
-        overridePaint: Paint()..color = Colors.white.withOpacity(1 - ((_verticalRenders - i) / 90.0)),
-      );
-
-      runningX += _horizontalDiffPerRender;
-      runninyY += verticalDiffPerRender;
-    }
   }
 
   void updateWallType(WallType wallType, {bool firstLoad = false}) {
@@ -98,21 +53,25 @@ class Wall extends PositionComponent with HasVisibility, HasWorldReference<MainW
     }
 
     _wallType = wallType;
-    _wallSprite = SpriteManager.getSprite('masonry/${wallType.name}-wall');
     scale = WallHelper.getScale(_wallType);
-    _totalHealth = WallHelper.getDefaultTotalHealth(_wallType);
-    _clearAndAddHitbox();
+    var newTotalHealth = WallHelper.getDefaultTotalHealth(_wallType);
 
-    if (!firstLoad) {
-      // We need to re-render the snapshot, we ignore first load as we're not in the render loop yet.
-      takeSnapshot();
+    if (_totalHealth != newTotalHealth && newTotalHealth > _totalHealth) {
+      // Add the difference to the health.
+      _health += newTotalHealth - _totalHealth;
     }
+
+    _totalHealth = newTotalHealth;
+
+    _clearAndAddHitbox();
+    _wallRenderer.renderWallType(firstLoad: firstLoad);
   }
 
   void reset() {
     updateWallType(WallType.wood);
     _health = _totalHealth;
     _hitbox?.collisionType = CollisionType.active;
+
     isVisible = true;
   }
 

--- a/lib/core/flame/components/masonry/walls/wall_helper.dart
+++ b/lib/core/flame/components/masonry/walls/wall_helper.dart
@@ -19,4 +19,13 @@ class WallHelper {
         return 140;
     }
   }
+
+  static int defenseValue(WallType type) {
+    switch (type) {
+      case WallType.wood:
+        return 0;
+      case WallType.stone:
+        return 1;
+    }
+  }
 }

--- a/lib/core/flame/components/masonry/walls/wall_renderer.dart
+++ b/lib/core/flame/components/masonry/walls/wall_renderer.dart
@@ -1,0 +1,74 @@
+import 'package:defend_your_flame/constants/parallax_constants.dart';
+import 'package:defend_your_flame/core/flame/components/masonry/walls/wall.dart';
+import 'package:defend_your_flame/core/flame/managers/sprite_manager.dart';
+import 'package:flame/components.dart';
+import 'package:flame/image_composition.dart';
+import 'package:flutter/material.dart';
+
+class WallRenderer extends PositionComponent with ParentIsA<Wall>, Snapshot {
+  static const double verticalDiffPerRender = 30;
+
+  double _verticalRange = 0;
+  double _horizontalRange = 0;
+  double _verticalRenders = 0;
+  double _horizontalDiffPerRender = 0;
+
+  late final double verticalRange;
+  late Sprite _wallSprite;
+
+  final List<Vector2> _wallCornerPoints = [];
+
+  List<Vector2> get wallCornerPoints => _wallCornerPoints;
+
+  WallRenderer({required this.verticalRange}) {
+    renderSnapshot = true;
+  }
+
+  _updateRenderValues() {
+    _verticalRange = verticalRange / parent.scale.y;
+    _verticalRenders = (_verticalRange / verticalDiffPerRender).ceilToDouble();
+
+    _horizontalRange = _verticalRange * ParallaxConstants.horizontalDisplacementFactor;
+    _horizontalDiffPerRender = _horizontalRange / _verticalRenders;
+  }
+
+  updateWallRenderValues() {
+    var wallType = parent.wallType;
+    _wallSprite = SpriteManager.getSprite('masonry/${wallType.name}-wall');
+
+    _updateRenderValues();
+    _wallCornerPoints.clear();
+    _wallCornerPoints.addAll([
+      Vector2(0, -size.y),
+      Vector2(size.x, -size.y),
+      Vector2(size.x + _horizontalRange, _verticalRange),
+      Vector2(_horizontalRange, _verticalRange),
+    ]);
+  }
+
+  @override
+  void render(Canvas canvas) {
+    super.render(canvas);
+
+    double runningX = 0;
+    double runninyY = 0;
+    for (int i = 0; i < _verticalRenders; i++) {
+      _wallSprite.render(
+        canvas,
+        position: Vector2(runningX, runninyY - size.y),
+        size: size,
+        overridePaint: Paint()..color = Colors.white.withOpacity(1 - ((_verticalRenders - i) / 90.0)),
+      );
+
+      runningX += _horizontalDiffPerRender;
+      runninyY += verticalDiffPerRender;
+    }
+  }
+
+  void renderWallType({bool firstLoad = false}) {
+    if (!firstLoad) {
+      // We need to re-render the snapshot, we ignore first load as we're not in the render loop yet.
+      takeSnapshot();
+    }
+  }
+}

--- a/lib/core/flame/components/projectiles/curving_magic_projectile.dart
+++ b/lib/core/flame/components/projectiles/curving_magic_projectile.dart
@@ -22,6 +22,8 @@ class CurvingMagicProjectile extends PositionComponent
   final Vector2 initialPosition;
   final Vector2 targetPosition;
 
+  final int damage;
+
   Vector2 _velocity = Vector2.zero();
 
   final double horizontalPixelsPerSecond;
@@ -36,6 +38,7 @@ class CurvingMagicProjectile extends PositionComponent
   CurvingMagicProjectile({
     required this.initialPosition,
     required this.targetPosition,
+    required this.damage,
     this.horizontalPixelsPerSecond = 170,
   }) {
     position = initialPosition.clone();
@@ -64,7 +67,7 @@ class CurvingMagicProjectile extends PositionComponent
 
     if (isCollidingWithWall) {
       removeFromParent();
-      world.playerManager.playerBase.takeDamage(15, position: wallIntersectionPoints.first);
+      world.playerManager.playerBase.takeDamage(damage, position: wallIntersectionPoints.first);
     }
 
     if (position.y > world.worldHeight + BoundingConstants.maxYCoordinateOffScreen) {

--- a/lib/core/flame/helpers/entity_spawn_helper.dart
+++ b/lib/core/flame/helpers/entity_spawn_helper.dart
@@ -21,7 +21,7 @@ class EntitySpawnHelper {
   static Entity spawnEntity({required double worldHeight, required double skyHeight, required int currentRound}) {
     var randomNumber = GlobalVars.rand.nextInt(100);
 
-    if (randomNumber < 95 - (currentRound * 2) || currentRound <= 2) {
+    if (randomNumber < 95 - (currentRound * 1.5) || currentRound <= 3) {
       return _spawnGroundEntity(worldHeight: worldHeight, currentRound: currentRound);
       // ignore: dead_code
     } else {
@@ -36,7 +36,7 @@ class EntitySpawnHelper {
     );
 
     var randomNumber = GlobalVars.rand.nextInt(100);
-    if (randomNumber < max(sqrt(currentRound * 5), 25) && currentRound > 2) {
+    if (randomNumber < max(sqrt(currentRound * 4), 25) && currentRound > 2) {
       return StrongSkeleton.spawn(position: startPosition);
     } else if (randomNumber < 70) {
       return Skeleton.spawn(position: startPosition);

--- a/lib/core/flame/managers/entity_manager.dart
+++ b/lib/core/flame/managers/entity_manager.dart
@@ -1,7 +1,6 @@
 import 'dart:collection';
 import 'dart:ui';
 
-import 'package:defend_your_flame/core/flame/components/entities/mobs/skeleton.dart';
 import 'package:defend_your_flame/core/flame/components/entities/entity.dart';
 import 'package:defend_your_flame/core/flame/helpers/entity_spawn_helper.dart';
 import 'package:defend_your_flame/core/flame/worlds/main_world.dart';

--- a/lib/core/flame/managers/player_manager.dart
+++ b/lib/core/flame/managers/player_manager.dart
@@ -6,7 +6,7 @@ class PlayerManager extends PositionComponent with ParentIsA<MainWorld> {
   late final PlayerBase _playerBase = PlayerBase()
     ..position = Vector2(parent.worldWidth - PlayerBase.baseWidth, parent.worldHeight - PlayerBase.baseHeight);
 
-  int _gold = 0;
+  int _gold = 100;
 
   int get totalGold => _gold;
   PlayerBase get playerBase => _playerBase;

--- a/lib/core/flame/managers/player_manager.dart
+++ b/lib/core/flame/managers/player_manager.dart
@@ -6,7 +6,7 @@ class PlayerManager extends PositionComponent with ParentIsA<MainWorld> {
   late final PlayerBase _playerBase = PlayerBase()
     ..position = Vector2(parent.worldWidth - PlayerBase.baseWidth, parent.worldHeight - PlayerBase.baseHeight);
 
-  int _gold = 100;
+  int _gold = 0;
 
   int get totalGold => _gold;
   PlayerBase get playerBase => _playerBase;

--- a/lib/core/shop/walls/stone_wall.dart
+++ b/lib/core/shop/walls/stone_wall.dart
@@ -4,7 +4,8 @@ class StoneWallPurchase extends Purchasable {
   StoneWallPurchase()
       : super(
           name: 'Stone Wall',
-          description: '"I found a wall of wood, and left it a wall\nof stone."',
+          description:
+              '- +40 max health\n\n- +1 defence\n\n\n\n"I found a wall of wood, and left it a wall\nof stone."',
           cost: 110,
           oneOffPurchase: true,
         );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: defend_your_flame
 description: Defend your castles flame from the enemy
 publish_to: 'none'
-version: 0.9.0+1 # +1 since we haven't actually published this yet
+version: 0.10.0+1 # +1 since we haven't actually published this yet
 
 environment:
   sdk: '>=3.1.2 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: defend_your_flame
 description: Defend your castles flame from the enemy
 publish_to: 'none'
-version: 0.10.0+1 # +1 since we haven't actually published this yet
+version: 0.9.1+1 # +1 since we haven't actually published this yet
 
 environment:
   sdk: '>=3.1.2 <4.0.0'


### PR DESCRIPTION
<img width="1093" alt="image" src="https://github.com/anleac/defend_your_flame/assets/13091188/2ad47e4b-39a9-4632-b253-278c645e9571">

This PR adds:
- Bump to 0.9.1 alpha
- Add concept of a wall defense
- Massively cleaned up the Wall class.

Changelog:

```
## 0.9.1 alpha - 28th April, 2024

### New Features
- Add concept of defense to a wall, which removes damage 1:1
   - Gave the stone wall upgrade a defense of 1 (wood has 0)

### Bug Fixes
- N/A

### Improvements
- Scaled the spawning logic better to prefer mages later on, and strong skeletons more in the early rounds
- Nerfed the mage damage
- Added a better description to the stone wall upgrade
```