### PR TITLE
Improvements to the defense totems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.12.2 alpha - 4th May, 2024
+
+### New Features
+- N/A
+
+### Bug Fixes
+- Fix attack totems incorrectly calculating velocity of moving targets
+
+### Improvements
+- More small UX improvements to the shop
+- Made the attack totems attack go through the wall for now
+- Made friction for horizontally thrown targets higher
+- Made the trajectory for attack totem attacks more accurate
+- Made the speed of totem attacks much faster
+
 ## 0.12.1 alpha - 4th May, 2024
 
 ### New Features

--- a/lib/constants/physics_constants.dart
+++ b/lib/constants/physics_constants.dart
@@ -2,7 +2,8 @@ import 'package:flame/components.dart';
 
 class PhysicsConstants {
   // Represented as a percentage of the velocity lost per second
-  static const double friction = 0.95;
+  // X friction is higher as Y is generally influenced by gravity
+  static final Vector2 friction = Vector2(0.90, 0.98);
   static final Vector2 gravity = Vector2(0, 2600.0);
 
   static final Vector2 magicalGravity = gravity / 8;

--- a/lib/constants/physics_constants.dart
+++ b/lib/constants/physics_constants.dart
@@ -6,8 +6,8 @@ class PhysicsConstants {
   static final Vector2 friction = Vector2(0.90, 0.98);
   static final Vector2 gravity = Vector2(0, 2600.0);
 
-  static final Vector2 magicalGravity = gravity / 8;
-  static final Vector2 strongMagicalGravity = gravity / 4;
+  static final Vector2 magicalGravity = gravity / 6;
+  static final Vector2 strongMagicalGravity = gravity / 2;
 
   static final Vector2 maxVelocity = Vector2(2000, 3000);
   static final Vector2 negativeMaxVelocity = -maxVelocity;

--- a/lib/constants/versioning_constants.dart
+++ b/lib/constants/versioning_constants.dart
@@ -9,7 +9,7 @@ class VersioningConstants {
 
   static const _majorVersion = 0;
   static const _minorVersion = 12;
-  static const _patchVersion = 1;
+  static const _patchVersion = 2;
 
   static const _releaseVersion = ReleaseVersion.alpha;
 

--- a/lib/core/flame/components/entities/entity.dart
+++ b/lib/core/flame/components/entities/entity.dart
@@ -2,6 +2,7 @@ import 'package:defend_your_flame/constants/bounding_constants.dart';
 import 'package:defend_your_flame/constants/misc_constants.dart';
 import 'package:defend_your_flame/core/flame/components/entities/enums/entity_state.dart';
 import 'package:defend_your_flame/core/flame/components/entities/configs/entity_config.dart';
+import 'package:defend_your_flame/core/flame/components/entities/mixins/has_hitbox_positioning.dart';
 import 'package:defend_your_flame/core/flame/main_game.dart';
 import 'package:defend_your_flame/core/flame/managers/entity_manager.dart';
 import 'package:defend_your_flame/core/flame/managers/sprite_manager.dart';
@@ -20,6 +21,7 @@ class Entity extends SpriteAnimationGroupComponent<EntityState>
         HasGameReference<MainGame>,
         HasVisibility,
         TapCallbacks,
+        HasHitboxPositioning,
         GestureHitboxes,
         CollisionCallbacks,
         HasWallCollision,

--- a/lib/core/flame/components/entities/mixins/has_hitbox_positioning.dart
+++ b/lib/core/flame/components/entities/mixins/has_hitbox_positioning.dart
@@ -1,0 +1,22 @@
+import 'package:flame/collisions.dart';
+import 'package:flame/components.dart';
+import 'package:flutter/material.dart';
+
+mixin HasHitboxPositioning on PositionComponent {
+  Iterable<ShapeHitbox> get hitboxes => children.query<ShapeHitbox>();
+
+  @override
+  @mustCallSuper
+  Future<void> onLoad() async {
+    super.onLoad();
+    children.register<ShapeHitbox>();
+  }
+
+  Vector2 absoluteCenterOfMainHitbox() {
+    if (hitboxes.isNotEmpty) {
+      return hitboxes.first.absoluteCenter;
+    }
+
+    return absoluteCenter;
+  }
+}

--- a/lib/core/flame/components/entities/mobs/mage.dart
+++ b/lib/core/flame/components/entities/mobs/mage.dart
@@ -52,7 +52,7 @@ class Mage extends FlyingEntity with DisappearOnDeath {
       isSolid: true);
 
   Mage({super.scaleModifier}) : super(flyingEntityConfig: _mageConfig) {
-    setDisappearSpeedFactor(2);
+    setDisappearSpeedFactor(3);
   }
 
   @override

--- a/lib/core/flame/components/hud/shop/main_shop_hud.dart
+++ b/lib/core/flame/components/hud/shop/main_shop_hud.dart
@@ -52,7 +52,7 @@ class MainShopHud extends BasicHud with ParentIsA<NextRoundHud> {
     ..anchor = Anchor.center;
 
   late final GoldIndicator _goldIndicator = GoldIndicator()
-    ..position = _headerRect.centerRight.toVector2() + Vector2(-_padding, 0)
+    ..position = _headerRect.centerRight.toVector2() - Vector2(_padding, 0)
     ..anchor = Anchor.centerRight
     ..scale = Vector2.all(1.5);
 
@@ -61,7 +61,7 @@ class MainShopHud extends BasicHud with ParentIsA<NextRoundHud> {
     ..anchor = Anchor.center;
 
   late final ShopItemDescription _shopItemDescription = ShopItemDescription()
-    ..position = _rightBodyRect.center.toVector2()
+    ..position = _rightBodyRect.center.toVector2() - Vector2(_padding, 0)
     ..anchor = Anchor.center
     ..size = _rightBodyRect.size.toVector2();
 

--- a/lib/core/flame/components/hud/shop/main_shop_hud.dart
+++ b/lib/core/flame/components/hud/shop/main_shop_hud.dart
@@ -61,7 +61,7 @@ class MainShopHud extends BasicHud with ParentIsA<NextRoundHud> {
     ..anchor = Anchor.center;
 
   late final ShopItemDescription _shopItemDescription = ShopItemDescription()
-    ..position = _rightBodyRect.center.toVector2() - Vector2(_padding, 0)
+    ..position = _rightBodyRect.center.toVector2()
     ..anchor = Anchor.center
     ..size = _rightBodyRect.size.toVector2();
 

--- a/lib/core/flame/components/hud/shop/shop_item_description.dart
+++ b/lib/core/flame/components/hud/shop/shop_item_description.dart
@@ -21,7 +21,7 @@ class ShopItemDescription extends PositionComponent
   late final ItemCostText _costText = ItemCostText()..position = _itemTitle.position + _itemGap;
 
   late final ItemDescriptionTitle _descriptionLabel = ItemDescriptionTitle()
-    ..position = _costText.position + (_itemGap * 2)
+    ..position = _costText.position + (_itemGap * 1.5)
     ..anchor = Anchor.topLeft;
 
   late final TextComponent _descriptionText = TextComponent(

--- a/lib/core/flame/components/masonry/totems/attack_totem.dart
+++ b/lib/core/flame/components/masonry/totems/attack_totem.dart
@@ -8,6 +8,8 @@ import 'package:defend_your_flame/helpers/global_vars.dart';
 import 'package:flame/components.dart';
 
 class AttackTotem extends PlayerBaseComponent {
+  static const double baseSpeed = 380;
+
   final StoneTotem _stoneTotem = StoneTotem();
   late final PurpleFlame _firePitFlame = PurpleFlame()
     ..scale = Vector2(1.4, 2.3)
@@ -35,7 +37,7 @@ class AttackTotem extends PlayerBaseComponent {
 
     if (_nextAttackCounter >= _attackCooldown) {
       _nextAttackCounter = 0;
-      _attackCooldown = GlobalVars.rand.nextDouble() * 2.5 + 1;
+      _attackCooldown = GlobalVars.rand.nextDouble() * 3 + 1.5;
 
       if (world.worldStateManager.playing) {
         var randomEnemy = world.entityManager.randomVisibleAliveEntity();
@@ -43,9 +45,10 @@ class AttackTotem extends PlayerBaseComponent {
         if (randomEnemy != null) {
           world.projectileManager.addProjectile(AttackTotemCurvingProjectile(
               initialPosition: absoluteCenter,
-              targetPosition: randomEnemy.absoluteCenter,
+              targetPosition: randomEnemy.absoluteCenterOfMainHitbox(),
               damage: 8,
-              targetXVelocity: randomEnemy.isWalking ? randomEnemy.entityConfig.walkingForwardSpeed.toDouble() : 0));
+              targetXVelocity: randomEnemy.isWalking ? randomEnemy.entityConfig.walkingForwardSpeed.toDouble() : 0,
+              horizontalPixelsPerSecond: baseSpeed + (GlobalVars.rand.nextDouble() * 100)));
         }
       }
     }

--- a/lib/core/flame/components/projectiles/concrete_curving_projectiles/attack_totem_curving_projectile.dart
+++ b/lib/core/flame/components/projectiles/concrete_curving_projectiles/attack_totem_curving_projectile.dart
@@ -6,11 +6,11 @@ class AttackTotemCurvingProjectile extends CurvingMagicProjectile {
       {required super.initialPosition,
       required super.targetPosition,
       required super.targetXVelocity,
+      required super.horizontalPixelsPerSecond,
       required super.damage})
       : super(
             colorFrom: const Color.fromARGB(255, 180, 10, 186),
             colorTo: const Color.fromARGB(255, 94, 0, 110),
-            horizontalPixelsPerSecond: 200,
             isFriendly: true,
             strongMagicalGravity: false);
 }

--- a/lib/core/flame/components/projectiles/curving_magic_projectile.dart
+++ b/lib/core/flame/components/projectiles/curving_magic_projectile.dart
@@ -68,7 +68,7 @@ class CurvingMagicProjectile extends PositionComponent
   @override
   FutureOr<void> onLoad() {
     add(_trailingParticles);
-    add(CircleHitbox(radius: 3));
+    add(CircleHitbox(radius: 4));
 
     return super.onLoad();
   }
@@ -80,12 +80,12 @@ class CurvingMagicProjectile extends PositionComponent
     _velocity = PhysicsHelper.applyCustomGravity(_velocity, _gravityInUse, dt);
     position = TimestepHelper.addVector2(position, _velocity, dt);
 
-    if (isCollidingWithWall) {
+    if (!isFriendly && isCollidingWithWall) {
       removeFromParent();
       if (!isFriendly) {
         world.playerBase.takeDamage(damage, position: wallIntersectionPoints.first);
       }
-    } else if (isCollidingWithEntity) {
+    } else if (isCollidingWithEntity && isFriendly) {
       removeFromParent();
       if (isFriendly) {
         collidedEntity?.takeDamage(damage.toDouble());

--- a/lib/core/flame/worlds/main_world.dart
+++ b/lib/core/flame/worlds/main_world.dart
@@ -10,6 +10,7 @@ import 'package:defend_your_flame/core/flame/managers/round_manager.dart';
 import 'package:defend_your_flame/core/flame/managers/shop_manager.dart';
 import 'package:defend_your_flame/core/flame/managers/world_state_manager.dart';
 import 'package:defend_your_flame/core/flame/worlds/main_world_state.dart';
+import 'package:defend_your_flame/helpers/platform_helper.dart';
 import 'package:flame/components.dart';
 
 class MainWorld extends World with HasCollisionDetection {
@@ -44,7 +45,9 @@ class MainWorld extends World with HasCollisionDetection {
     add(_projectileManager);
     add(_effectManager);
 
-    add(CameraBorder());
+    if (!PlatformHelper.isWeb) {
+      add(CameraBorder());
+    }
 
     // Generally, we should add the HUD to the camera viewpoint to ensure it doesn't move
     // with the world. However, in this case, we have no camera movement and therefore

--- a/lib/helpers/physics_helper.dart
+++ b/lib/helpers/physics_helper.dart
@@ -16,7 +16,9 @@ class PhysicsHelper {
   }
 
   static Vector2 applyFriction(Vector2 velocity, double dt) {
-    return TimestepHelper.multiplyVector2(velocity, PhysicsConstants.friction, dt);
+    velocity.x = TimestepHelper.multiply(velocity.x, PhysicsConstants.friction.x, dt);
+    velocity.y = TimestepHelper.multiply(velocity.y, PhysicsConstants.friction.y, dt);
+    return velocity;
   }
 
   static bool pointIsInsideBounds({required Vector2 point, required Vector2 size, Vector2? position, Vector2? offset}) {

--- a/lib/helpers/physics_helper.dart
+++ b/lib/helpers/physics_helper.dart
@@ -36,15 +36,14 @@ class PhysicsHelper {
       required double horizontalPixelsPerSecond,
       required Vector2 gravity,
       double targetXVelocity = 0}) {
-    double relativeHorizontalSpeed = horizontalPixelsPerSecond - targetXVelocity;
-
     double distanceX = targetPosition.x - initialPosition.x;
+    double time = distanceX.abs() / horizontalPixelsPerSecond;
+
     double distanceY = targetPosition.y - initialPosition.y;
 
-    double time = distanceX.abs() / relativeHorizontalSpeed;
-
     double vy = distanceY / time - 0.5 * gravity.y * time;
+    double vx = horizontalPixelsPerSecond * (distanceX >= 0 ? 1 : -1) + targetXVelocity;
 
-    return Vector2(relativeHorizontalSpeed * (distanceX >= 0 ? 1 : -1), vy);
+    return Vector2(vx, vy);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: defend_your_flame
 description: Defend your castles flame from the enemy
 publish_to: 'none'
-version: 0.12.1+1 # +1 since we haven't actually published this yet
+version: 0.12.2+1 # +1 since we haven't actually published this yet
 
 environment:
   sdk: '>=3.1.2 <4.0.0'


### PR DESCRIPTION
From the changelog:

```
## 0.12.2 alpha - 4th May, 2024

### New Features
- N/A

### Bug Fixes
- Fix attack totems incorrectly calculating velocity of moving targets

### Improvements
- More small UX improvements to the shop
- Made the attack totems attack go through the wall for now
- Made friction for horizontally thrown targets higher
- Made the trajectory for attack totem attacks more accurate
- Made the speed of totem attacks much faster
```

https://github.com/anleac/defend_your_flame/assets/13091188/795de456-261e-4c30-96f1-e1efde4cc2c1


