### PR TITLE
Polishes to difficulty and small UX polishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.13.1 alpha - 5th May, 2024
+
+### New Features
+- N/A
+
+### Bug Fixes
+- Fixed the wrong bold-ing of titles in the Shop HUD
+- Fixed wall health not being reset on game restart if you hadn't purchased any wall upgrades
+
+### Improvements
+- Improved the detection of entity collisions when drag distance is small
+- Reduced the distance entities can go off the left/right of the screen
+- Added in a "round you made it to" text on the game over screen
+- Made the spawn duration each round slightly longer
+- Made both mages and strong skeletons spawn one round later
+   - Also made both spawn slightly less into later rounds
+
 ## 0.13.0 alpha - 5th May, 2024
 
 ### New Features

--- a/lib/constants/bounding_constants.dart
+++ b/lib/constants/bounding_constants.dart
@@ -1,7 +1,7 @@
 class BoundingConstants {
   // Constants for the bounding box of the draggable entity
-  static const double minYCoordinate = -250;
-  static const double maxYCoordinateOffScreen = 150;
-  static const double maxXCoordinateOffScreen = 150;
+  static const double minYCoordinate = -150;
+  static const double maxYCoordinateOffScreen = 100;
+  static const double maxXCoordinateOffScreen = 100;
   static const double minXCoordinateOffScreen = -maxXCoordinateOffScreen;
 }

--- a/lib/constants/entity_spawn_constants.dart
+++ b/lib/constants/entity_spawn_constants.dart
@@ -1,4 +1,4 @@
 class EntitySpawnConstants {
-  static const int roundToStartSpawningStrongGroundEnemies = 4;
-  static const int roundToStartSpawningStrongFlyingEnemies = 7;
+  static const int roundToStartSpawningStrongGroundEnemies = 5;
+  static const int roundToStartSpawningStrongFlyingEnemies = 8;
 }

--- a/lib/constants/translations/app_string_data.dart
+++ b/lib/constants/translations/app_string_data.dart
@@ -8,6 +8,7 @@ class AppStringData {
       'saveGame': 'Save Game',
       'restartGame': 'Restart Game',
       'gameOver': 'Game Over',
+      'gameOverRoundText': 'You made it to round ${AppStrings.placeholderText}',
       'back': 'Back',
       'startRound': 'Start Next Round',
       'healthIndicatorAmount': '${AppStrings.placeholderText}/${AppStrings.placeholderText}',

--- a/lib/constants/translations/app_strings.dart
+++ b/lib/constants/translations/app_strings.dart
@@ -55,6 +55,7 @@ class AppStrings {
   String roundText(int round) => AppStringHelper.insertNumber(getValue('roundText'), round);
   String get restartGame => getValue('restartGame');
   String get gameOver => getValue('gameOver');
+  String get gameOverRoundText => getValue('gameOverRoundText');
   String get back => getValue('back');
   String get healthIndicatorText => getValue('healthIndicatorAmount');
 

--- a/lib/constants/versioning_constants.dart
+++ b/lib/constants/versioning_constants.dart
@@ -9,7 +9,7 @@ class VersioningConstants {
 
   static const _majorVersion = 0;
   static const _minorVersion = 13;
-  static const _patchVersion = 0;
+  static const _patchVersion = 1;
 
   static const _releaseVersion = ReleaseVersion.alpha;
 

--- a/lib/core/flame/components/entities/draggable_entity.dart
+++ b/lib/core/flame/components/entities/draggable_entity.dart
@@ -61,7 +61,7 @@ class DraggableEntity extends Entity with DragCallbacks {
   }
 
   void stopDraggingAndBounce() {
-    _velocity = _velocity * -0.1;
+    _velocity = _velocity * -0.05;
     stopDragging();
   }
 
@@ -116,7 +116,7 @@ class DraggableEntity extends Entity with DragCallbacks {
   }
 
   void _updateDragVelocity(Vector2 newVelocity) {
-    double influence = newVelocity == Vector2.zero() ? 0.15 : 0.22;
+    double influence = newVelocity == Vector2.zero() ? 0.15 : 0.3;
     _dragVelocity.x = influence * newVelocity.x + (1 - influence) * _dragVelocity.x;
     _dragVelocity.y = influence * newVelocity.y + (1 - influence) * _dragVelocity.y;
 

--- a/lib/core/flame/components/hud/game_over_hud.dart
+++ b/lib/core/flame/components/hud/game_over_hud.dart
@@ -1,23 +1,40 @@
 import 'dart:async';
 
+import 'package:defend_your_flame/constants/translations/app_string_helper.dart';
 import 'package:defend_your_flame/core/flame/components/hud/base_components/basic_hud.dart';
 import 'package:defend_your_flame/core/flame/components/hud/buttons/restart_game_button.dart';
 import 'package:defend_your_flame/core/flame/components/hud/text/game_over_text.dart';
+import 'package:defend_your_flame/core/flame/main_game.dart';
+import 'package:defend_your_flame/core/flame/managers/text/text_manager.dart';
 import 'package:flame/components.dart';
 
-class GameOverHud extends BasicHud {
+class GameOverHud extends BasicHud with HasGameReference<MainGame> {
   late final GameOverText _gameOverText = GameOverText()
     ..position = Vector2(world.worldWidth / 2, 80)
     ..anchor = Anchor.center;
 
   late final RestartGameButton _restartGameButton = RestartGameButton()
-    ..position = Vector2(world.worldWidth / 2, world.worldHeight / 3)
+    ..position = Vector2(world.worldWidth / 2, world.worldHeight / 2)
     ..anchor = Anchor.center;
+
+  late final TextComponent _roundText = TextComponent(
+    text: '',
+    textRenderer: TextManager.smallSubHeaderBoldRenderer,
+  )
+    ..position = (_gameOverText.center + _restartGameButton.center) / 2
+    ..anchor = Anchor.center;
+
+  @override
+  void onMount() {
+    _roundText.text = AppStringHelper.insertNumber(game.appStrings.gameOverRoundText, world.roundManager.currentRound);
+    super.onMount();
+  }
 
   @override
   FutureOr<void> onLoad() {
     add(_gameOverText);
     add(_restartGameButton);
+    add(_roundText);
 
     return super.onLoad();
   }

--- a/lib/core/flame/components/hud/shop/shop_item_description.dart
+++ b/lib/core/flame/components/hud/shop/shop_item_description.dart
@@ -26,7 +26,7 @@ class ShopItemDescription extends PositionComponent
 
   late final TextComponent _descriptionText = TextComponent(
     text: '',
-    textRenderer: TextManager.smallSubHeaderBoldRenderer,
+    textRenderer: TextManager.smallSubHeaderRenderer,
   )..position = _descriptionLabel.position + _itemGap;
 
   late final TextComponent _purchaseCountText = TextComponent(

--- a/lib/core/flame/components/hud/text/shop/item_description_title.dart
+++ b/lib/core/flame/components/hud/text/shop/item_description_title.dart
@@ -2,7 +2,7 @@ import 'package:defend_your_flame/core/flame/components/hud/base_components/defa
 import 'package:defend_your_flame/core/flame/managers/text/text_manager.dart';
 
 class ItemDescriptionTitle extends DefaultText {
-  ItemDescriptionTitle() : super(textRenderer: TextManager.smallSubHeaderRenderer);
+  ItemDescriptionTitle() : super(textRenderer: TextManager.smallSubHeaderBoldRenderer);
 
   @override
   void onMount() {

--- a/lib/core/flame/components/masonry/walls/wall.dart
+++ b/lib/core/flame/components/masonry/walls/wall.dart
@@ -40,7 +40,7 @@ class Wall extends PositionComponent with HasVisibility, HasWorldReference<MainW
     _setWallStats();
   }
 
-  _setWallStats({bool resetHealth = true}) {
+  _setWallStats({bool resetWall = true}) {
     // Needed simply for rendering, not logic, but changes based on wall type.
     size = WallHelper.getWallSize(_wallType);
     scale = WallHelper.getScale(_wallType);
@@ -49,7 +49,7 @@ class Wall extends PositionComponent with HasVisibility, HasWorldReference<MainW
     _totalHealth = WallHelper.totalHealth(_wallType);
     _defenseValue = WallHelper.defenseValue(_wallType);
 
-    if (resetHealth) {
+    if (resetWall) {
       _health = _totalHealth;
     }
   }
@@ -74,8 +74,8 @@ class Wall extends PositionComponent with HasVisibility, HasWorldReference<MainW
     );
   }
 
-  void updateWallType(WallType wallType, {bool firstLoad = false, bool resetHealth = false}) {
-    if (!firstLoad && _wallType == wallType) {
+  void updateWallType(WallType wallType, {bool firstLoad = false, bool resetWall = false}) {
+    if (!firstLoad && _wallType == wallType && !resetWall) {
       return;
     }
 
@@ -86,14 +86,14 @@ class Wall extends PositionComponent with HasVisibility, HasWorldReference<MainW
       _health += newTotalHealth - _totalHealth;
     }
 
-    _setWallStats(resetHealth: resetHealth);
+    _setWallStats(resetWall: resetWall);
 
     _clearAndAddHitbox();
     _wallRenderer.renderWallType(firstLoad: firstLoad);
   }
 
   void reset() {
-    updateWallType(WallType.barricade, resetHealth: true);
+    updateWallType(WallType.barricade, resetWall: true);
 
     _hitbox?.collisionType = CollisionType.active;
     isVisible = true;

--- a/lib/core/flame/components/masonry/walls/wall_helper.dart
+++ b/lib/core/flame/components/masonry/walls/wall_helper.dart
@@ -37,9 +37,9 @@ class WallHelper {
       case WallType.barricade:
         return 80;
       case WallType.wood:
-        return 100;
+        return 120;
       case WallType.stone:
-        return 140;
+        return 160;
     }
   }
 

--- a/lib/core/flame/helpers/entity_spawn_helper.dart
+++ b/lib/core/flame/helpers/entity_spawn_helper.dart
@@ -62,6 +62,10 @@ class EntitySpawnHelper {
   }
 
   static double _tapper(double input) {
+    if (input <= 0) {
+      return 1;
+    }
+
     const double tapper = 0.6;
     // This is a tapper function that will make the spawn rate increase slower as the rounds progress
     // I tried sqrt but it was a bit too high of tappering
@@ -69,16 +73,16 @@ class EntitySpawnHelper {
   }
 
   static double _secondsToSpawnOver(int currentRound) {
-    return _tapper(currentRound * 12).ceil() + 5;
+    return _tapper(currentRound * 14).ceil() + 6;
   }
 
-  static int _basicMobsToSpawnThisRound(int currentRound) => _tapper(currentRound * 12).ceil() + 3;
+  static int _basicMobsToSpawnThisRound(int currentRound) => _tapper(currentRound * 12).ceil() + 4;
   static int _strongGroundMobsToSpawnThisRound(int currentRound) {
     if (currentRound < EntitySpawnConstants.roundToStartSpawningStrongGroundEnemies) {
       return 0;
     }
 
-    return _tapper((currentRound - EntitySpawnConstants.roundToStartSpawningStrongGroundEnemies) * 5).ceil();
+    return _tapper((currentRound - EntitySpawnConstants.roundToStartSpawningStrongGroundEnemies) * 4).ceil();
   }
 
   static int _flyingMobsToSpawnThisRound(int currentRound) {
@@ -86,7 +90,7 @@ class EntitySpawnHelper {
       return 0;
     }
 
-    return _tapper((currentRound - EntitySpawnConstants.roundToStartSpawningStrongFlyingEnemies) * 3).ceil();
+    return _tapper((currentRound - EntitySpawnConstants.roundToStartSpawningStrongFlyingEnemies) * 2).ceil();
   }
 
   static Vector2 _randomGroundSpawnPosition({required double worldHeight}) {

--- a/lib/core/flame/shop/purchasable.dart
+++ b/lib/core/flame/shop/purchasable.dart
@@ -16,7 +16,7 @@ abstract class Purchasable {
   bool get purchasedMaxAmount => _purchaseCount >= maxPurchaseCount;
   int get purchaseCount => _purchaseCount;
 
-  int get currentCost => cost[_purchaseCount];
+  int get currentCost => _purchaseCount >= cost.length ? cost.last : cost[_purchaseCount];
 
   Purchasable(
       {required this.name,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: defend_your_flame
 description: Defend your castles flame from the enemy
 publish_to: 'none'
-version: 0.13.0+1 # +1 since we haven't actually published this yet
+version: 0.13.1+1 # +1 since we haven't actually published this yet
 
 environment:
   sdk: '>=3.1.2 <4.0.0'


### PR DESCRIPTION
Bumped to 0.13.1, after testing a bit of 0.13.0, these are some of the polishes, from the changelog:

```
## 0.13.1 alpha - 5th May, 2024

### New Features
- N/A

### Bug Fixes
- Fixed the wrong bold-ing of titles in the Shop HUD
- Fixed wall health not being reset on game restart if you hadn't purchased any wall upgrades

### Improvements
- Improved the detection of entity collisions when drag distance is small
- Reduced the distance entities can go off the left/right of the screen
- Added in a "round you made it to" text on the game over screen
- Made the spawn duration each round slightly longer
- Made both mages and strong skeletons spawn one round later
   - Also made both spawn slightly less into later rounds
```