### PR TITLE
Update between rounds HUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 6th May, 2024
+
+### New Features
+- N/A
+
+### Bug Fixes
+- N/A
+
+### Improvements
+- Overhauled the between rounds menu
+   - Now includes the context of the round, health, gold, etc
+   - Includes now a random tip each round
+- Small updates to the shop HUD
+
 ## 0.13.1 alpha - 5th May, 2024
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 6th May, 2024
+## 0.13.2 alpha - 6th May, 2024
 
 ### New Features
 - N/A

--- a/lib/constants/translations/app_string_constants.dart
+++ b/lib/constants/translations/app_string_constants.dart
@@ -1,0 +1,4 @@
+class AppStringConstants {
+  static const int amountOfTips = 5;
+  static const String descriptionGap = '\n';
+}

--- a/lib/constants/translations/app_string_data.dart
+++ b/lib/constants/translations/app_string_data.dart
@@ -5,6 +5,7 @@ class AppStringData {
   static final Map<String, Map<String, String>> values = {
     'en': {
       'roundText': 'Round ${AppStrings.placeholderText}',
+      'endOfRoundText': 'End Of Round ${AppStrings.placeholderText}',
       'saveGame': 'Save Game',
       'restartGame': 'Restart Game',
       'gameOver': 'Game Over',

--- a/lib/constants/translations/app_string_data.dart
+++ b/lib/constants/translations/app_string_data.dart
@@ -32,6 +32,13 @@ class AppStringData {
       'noItemSelected': 'No item selected',
       'potentialPurchaseCount': '${AppStrings.placeholderText}/${AppStrings.placeholderText} purchased',
 
+      // Tips
+      'gameTip0': 'Injure flying enemies by throwing others into them or by tapping',
+      'gameTip1': 'Dimensia is a hidden gem of a game',
+      'gameTip2': 'Be careful of throwing enemies into your wall to avoid damaging it',
+      'gameTip3': 'Flying enemies can not be dragged, but they can be tapped and collided with',
+      'gameTip4': 'Ensure to use your gold to upgrade your defenses between rounds',
+
       // Purchasables
       'woodenWallName': 'Wooden Wall',
       'woodenWallDescription': AppStringHelper.purchasableDescription(attributes: [

--- a/lib/constants/translations/app_string_helper.dart
+++ b/lib/constants/translations/app_string_helper.dart
@@ -1,12 +1,11 @@
+import 'package:defend_your_flame/constants/translations/app_string_constants.dart';
 import 'package:defend_your_flame/constants/translations/app_strings.dart';
 
 class AppStringHelper {
-  static const String _descriptionGap = '\n';
-
   static String purchasableDescription({required List<String> attributes}) {
     var description = '';
     for (var attribute in attributes) {
-      description += '- $attribute$_descriptionGap';
+      description += '- $attribute${AppStringConstants.descriptionGap}';
     }
 
     return description;

--- a/lib/constants/translations/app_strings.dart
+++ b/lib/constants/translations/app_strings.dart
@@ -1,5 +1,7 @@
+import 'package:defend_your_flame/constants/translations/app_string_constants.dart';
 import 'package:defend_your_flame/constants/translations/app_string_data.dart';
 import 'package:defend_your_flame/constants/translations/app_string_helper.dart';
+import 'package:defend_your_flame/helpers/global_vars.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -93,4 +95,6 @@ class AppStrings {
   String get stoneWallName => getValue('stoneWallName');
   String get stoneWallDescription => getValue('stoneWallDescription');
   String get stoneWallQuote => getValue('stoneWallQuote');
+
+  String getRandomTip() => getValue('gameTip${GlobalVars.rand.nextInt(AppStringConstants.amountOfTips)}');
 }

--- a/lib/constants/translations/app_strings.dart
+++ b/lib/constants/translations/app_strings.dart
@@ -53,6 +53,7 @@ class AppStrings {
 
   // Below this are declarations of all the strings used in the app, above is setup.
   String roundText(int round) => AppStringHelper.insertNumber(getValue('roundText'), round);
+  String endOfRoundText(int round) => AppStringHelper.insertNumber(getValue('endOfRoundText'), round);
   String get restartGame => getValue('restartGame');
   String get gameOver => getValue('gameOver');
   String get gameOverRoundText => getValue('gameOverRoundText');

--- a/lib/constants/versioning_constants.dart
+++ b/lib/constants/versioning_constants.dart
@@ -9,7 +9,7 @@ class VersioningConstants {
 
   static const _majorVersion = 0;
   static const _minorVersion = 13;
-  static const _patchVersion = 1;
+  static const _patchVersion = 2;
 
   static const _releaseVersion = ReleaseVersion.alpha;
 

--- a/lib/core/flame/components/hud/level_hud.dart
+++ b/lib/core/flame/components/hud/level_hud.dart
@@ -13,7 +13,7 @@ class LevelHud extends BasicHud {
   static final Vector2 _hudScale = Vector2.all(1.2);
 
   static final Vector2 _topLeftTextGap = Vector2(0, 30);
-  static final Vector2 _topRightTextGap = Vector2(0, 42);
+  static final Vector2 _topRightTextGap = Vector2(0, 30);
 
   late final VersionText _versionText = VersionText()
     ..position = Vector2.all(padding)
@@ -25,19 +25,21 @@ class LevelHud extends BasicHud {
     ..anchor = Anchor.topLeft
     ..scale = _hudScale;
 
-  late final RoundText _roundText = RoundText()
-    ..position = Vector2(world.worldWidth / 2, padding - 5) // Slightly less padding because the text is large.
-    ..anchor = Anchor.topCenter;
+  late final RoundText _roundText = RoundText(betweenRoundsHud: betweenRoundsHud);
 
   late final HealthIndicator _healthIndicator = HealthIndicator()
     ..position = Vector2(world.worldWidth - 15, padding)
-    ..anchor = Anchor.centerRight
+    ..anchor = Anchor.topRight
     ..scale = Vector2.all(1.2);
 
   late final GoldIndicator _goldIndicator = GoldIndicator()
     ..position = _healthIndicator.position + (_topRightTextGap * _healthIndicator.scale.y)
-    ..anchor = Anchor.centerRight
+    ..anchor = Anchor.topRight
     ..scale = _healthIndicator.scale;
+
+  final bool betweenRoundsHud;
+
+  LevelHud({this.betweenRoundsHud = false});
 
   @override
   FutureOr<void> onLoad() {

--- a/lib/core/flame/components/hud/next_round_internal/next_round_menu_hud.dart
+++ b/lib/core/flame/components/hud/next_round_internal/next_round_menu_hud.dart
@@ -5,6 +5,7 @@ import 'package:defend_your_flame/core/flame/components/hud/buttons/between_roun
 import 'package:defend_your_flame/core/flame/components/hud/buttons/between_rounds/save_game_button.dart';
 import 'package:defend_your_flame/core/flame/components/hud/level_hud.dart';
 import 'package:defend_your_flame/core/flame/components/hud/next_round_hud.dart';
+import 'package:defend_your_flame/core/flame/components/hud/text/tip_text.dart';
 import 'package:flame/components.dart';
 
 class NextRoundMenuHud extends BasicHud with ParentIsA<NextRoundHud> {
@@ -19,12 +20,15 @@ class NextRoundMenuHud extends BasicHud with ParentIsA<NextRoundHud> {
 
   late final LevelHud _levelHud = LevelHud();
 
+  late final TipText _tipText = TipText()..position = Vector2(world.worldWidth / 2, world.worldHeight - 120);
+
   @override
   Future<void> onLoad() async {
     add(_nextRound);
     add(_enterShop);
     add(_saveGameButton);
     add(_levelHud);
+    add(_tipText);
 
     return super.onLoad();
   }

--- a/lib/core/flame/components/hud/next_round_internal/next_round_menu_hud.dart
+++ b/lib/core/flame/components/hud/next_round_internal/next_round_menu_hud.dart
@@ -3,6 +3,7 @@ import 'package:defend_your_flame/core/flame/components/hud/base_components/basi
 import 'package:defend_your_flame/core/flame/components/hud/buttons/between_rounds/enter_shop_button.dart';
 import 'package:defend_your_flame/core/flame/components/hud/buttons/between_rounds/next_round_button.dart';
 import 'package:defend_your_flame/core/flame/components/hud/buttons/between_rounds/save_game_button.dart';
+import 'package:defend_your_flame/core/flame/components/hud/level_hud.dart';
 import 'package:defend_your_flame/core/flame/components/hud/next_round_hud.dart';
 import 'package:flame/components.dart';
 
@@ -16,11 +17,14 @@ class NextRoundMenuHud extends BasicHud with ParentIsA<NextRoundHud> {
   late final SaveGameButton _saveGameButton = SaveGameButton()
     ..position = _enterShop.position + ThemingConstants.menuButtonGap;
 
+  late final LevelHud _levelHud = LevelHud();
+
   @override
   Future<void> onLoad() async {
     add(_nextRound);
     add(_enterShop);
     add(_saveGameButton);
+    add(_levelHud);
 
     return super.onLoad();
   }

--- a/lib/core/flame/components/hud/shop/main_shop_hud.dart
+++ b/lib/core/flame/components/hud/shop/main_shop_hud.dart
@@ -7,6 +7,7 @@ import 'package:defend_your_flame/core/flame/components/hud/next_round_internal/
 import 'package:defend_your_flame/core/flame/components/hud/shop/shop_item_description.dart';
 import 'package:defend_your_flame/core/flame/components/hud/shop/shop_item_list.dart';
 import 'package:defend_your_flame/core/flame/components/hud/sprite_with_texts/gold_indicator.dart';
+import 'package:defend_your_flame/core/flame/components/hud/sprite_with_texts/health_indicator.dart';
 import 'package:defend_your_flame/core/flame/components/hud/text/shop/no_item_selected_text.dart';
 import 'package:defend_your_flame/core/flame/components/hud/text/shop/shop_title_text.dart';
 import 'package:defend_your_flame/core/flame/shop/purchasable.dart';
@@ -56,6 +57,11 @@ class MainShopHud extends BasicHud with ParentIsA<NextRoundHud> {
     ..anchor = Anchor.centerRight
     ..scale = Vector2.all(1.5);
 
+  late final HealthIndicator _healthIndicator = HealthIndicator()
+    ..position = _headerRect.centerLeft.toVector2() + Vector2(_padding, 0)
+    ..anchor = Anchor.centerLeft
+    ..scale = _goldIndicator.scale;
+
   late final NoItemSelectedText _noItemSelectedText = NoItemSelectedText()
     ..position = _rightBodyRect.center.toVector2()
     ..anchor = Anchor.center;
@@ -87,6 +93,7 @@ class MainShopHud extends BasicHud with ParentIsA<NextRoundHud> {
     add(_noItemSelectedText);
     add(_shopTitleText);
     add(_goldIndicator);
+    add(_healthIndicator);
     add(_backButton);
 
     return super.onLoad();

--- a/lib/core/flame/components/hud/sprite_with_texts/health_indicator.dart
+++ b/lib/core/flame/components/hud/sprite_with_texts/health_indicator.dart
@@ -8,9 +8,12 @@ import 'package:defend_your_flame/core/flame/worlds/main_world.dart';
 import 'package:flame/components.dart';
 
 class HealthIndicator extends PositionComponent with HasWorldReference<MainWorld>, HasGameReference<MainGame> {
-  late final RockHeart _rockHeart = RockHeart()..scale = Vector2.all(0.25);
+  late final RockHeart _rockHeart = RockHeart()
+    ..scale = Vector2.all(0.24)
+    ..anchor = Anchor.centerLeft;
 
-  late final TextComponent _healthText = TextComponent(textRenderer: TextManager.basicHudRenderer);
+  late final TextComponent _healthText = TextComponent(textRenderer: TextManager.basicHudRenderer)
+    ..anchor = Anchor.centerLeft;
 
   late final SpriteWithText _indicator = SpriteWithText(sprite: _rockHeart, text: _healthText);
 

--- a/lib/core/flame/components/hud/text/round_text.dart
+++ b/lib/core/flame/components/hud/text/round_text.dart
@@ -7,14 +7,24 @@ class RoundText extends DefaultText with HasWorldReference<MainWorld> {
   int _currentRound = 0;
 
   String get _roundText => game.appStrings.roundText(_currentRound);
+  String get _endOfRoundText => game.appStrings.endOfRoundText(_currentRound);
 
-  RoundText() : super(textRenderer: TextManager.headerRenderer);
+  final bool betweenRoundsHud;
+
+  RoundText({required this.betweenRoundsHud})
+      : super(textRenderer: TextManager.headerRenderer, anchor: Anchor.topCenter);
+
+  @override
+  void onMount() {
+    position = Vector2(world.worldWidth / 2, 10);
+    super.onMount();
+  }
 
   @override
   void update(double dt) {
     if (world.roundManager.currentRound != _currentRound) {
       _currentRound = world.roundManager.currentRound;
-      text = _roundText;
+      text = betweenRoundsHud ? _endOfRoundText : _roundText;
     }
 
     super.update(dt);

--- a/lib/core/flame/components/hud/text/tip_text.dart
+++ b/lib/core/flame/components/hud/text/tip_text.dart
@@ -1,0 +1,43 @@
+import 'package:defend_your_flame/core/flame/components/hud/backgrounds/bordered_background.dart';
+import 'package:defend_your_flame/core/flame/main_game.dart';
+import 'package:defend_your_flame/core/flame/managers/text/text_manager.dart';
+import 'package:defend_your_flame/core/flame/worlds/main_world.dart';
+import 'package:flame/components.dart';
+
+class TipText extends PositionComponent with HasWorldReference<MainWorld>, HasGameReference<MainGame> {
+  static const double padding = 15;
+
+  late final TextComponent _tipText = TextComponent(textRenderer: TextManager.basicHudItalicRenderer)
+    ..anchor = Anchor.center;
+
+  late final BorderedBackground _background = BorderedBackground()..anchor = Anchor.center;
+
+  String _currentTipText = '';
+  int _currentRound = -1;
+
+  @override
+  Future<void> onLoad() async {
+    add(_background);
+    add(_tipText);
+
+    return super.onLoad();
+  }
+
+  @override
+  void update(double dt) {
+    if (world.roundManager.currentRound != _currentRound) {
+      _currentRound = world.roundManager.currentRound;
+      _setTip(game.appStrings.getRandomTip());
+    }
+
+    super.update(dt);
+  }
+
+  _setTip(String tip) {
+    if (_currentTipText != tip) {
+      _currentTipText = tip;
+      _tipText.text = tip;
+      _background.size = _tipText.size + Vector2.all(padding * 2);
+    }
+  }
+}

--- a/lib/core/flame/managers/world_state_manager.dart
+++ b/lib/core/flame/managers/world_state_manager.dart
@@ -3,7 +3,8 @@ import 'package:defend_your_flame/constants/debug_constants.dart';
 import 'package:defend_your_flame/core/flame/worlds/main_world_state.dart';
 
 class WorldStateManager {
-  MainWorldState _currentState = DebugConstants.testShopLogic ? MainWorldState.betweenRounds : MainWorldState.mainMenu;
+  MainWorldState _currentState =
+      DebugConstants.testShopLogic ? MainWorldState.betweenRounds : MainWorldState.betweenRounds;
   MainWorldState get currentState => _currentState;
 
   bool get mainMenu => _currentState == MainWorldState.mainMenu;

--- a/lib/core/flame/managers/world_state_manager.dart
+++ b/lib/core/flame/managers/world_state_manager.dart
@@ -3,8 +3,7 @@ import 'package:defend_your_flame/constants/debug_constants.dart';
 import 'package:defend_your_flame/core/flame/worlds/main_world_state.dart';
 
 class WorldStateManager {
-  MainWorldState _currentState =
-      DebugConstants.testShopLogic ? MainWorldState.betweenRounds : MainWorldState.betweenRounds;
+  MainWorldState _currentState = DebugConstants.testShopLogic ? MainWorldState.betweenRounds : MainWorldState.mainMenu;
   MainWorldState get currentState => _currentState;
 
   bool get mainMenu => _currentState == MainWorldState.mainMenu;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: defend_your_flame
 description: Defend your castles flame from the enemy
 publish_to: 'none'
-version: 0.13.1+1 # +1 since we haven't actually published this yet
+version: 0.13.2+1 # +1 since we haven't actually published this yet
 
 environment:
   sdk: '>=3.1.2 <4.0.0'


### PR DESCRIPTION
![image](https://github.com/anleac/defend_your_flame/assets/13091188/097f9fd9-f2ee-45f9-bbec-78c1fae64985)

From the changelog:
```
## 0.13.2 alpha - 6th May, 2024

### New Features
- N/A

### Bug Fixes
- N/A

### Improvements
- Overhauled the between rounds menu
   - Now includes the context of the round, health, gold, etc
   - Includes now a random tip each round
- Small updates to the shop HUD
```