### PR TITLE
Balance fixes with the boss rounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.15.1 alpha - 13th May, 2024
+
+### New Features
+- N/A
+
+### Bug Fixes
+- Fixed gold starting at 10,000 - this is now correctly back at 0
+
+### Improvements / Balances
+- Overhauled the game start menu
+  - There is now an additional screen for selecting a game
+  - You can now fast track to round 10 or 15 with additional gold
+- Removed the "moon-click" fast track in favour of the new game start menu
+- Clicking the moon between rounds now gives gold, this is temporary for debugging purposes while testing in alpha
+- Improved the visual effects of damage and gold
+- Scaled the totem cost now to get progressively more expensive by 30% each time
+- Small improvements to the positioning of the wall
+- Small improvements to where damage text is positioned on mage and strong skeletons
+
 ## 0.15.0 alpha - 10th May, 2024
 
 ### New Features

--- a/lib/constants/entity_spawn_constants.dart
+++ b/lib/constants/entity_spawn_constants.dart
@@ -12,9 +12,10 @@ class EntitySpawnConstants {
 
   static const Map<int, List<Type>> bossRounds = {
     10: [DeathReaper],
+    15: [DeathReaper, DeathReaper],
     20: [FireBeast],
-    25: [DeathReaper, DeathReaper],
-    30: [DeathReaper, FireBeast, DeathReaper],
+    25: [DeathReaper, FireBeast, DeathReaper],
+    30: [FireBeast, FireBeast, FireBeast],
   };
 
   static const Set<Type> weakGroundMobs = {Slime, Skeleton};

--- a/lib/constants/experimental_constants.dart
+++ b/lib/constants/experimental_constants.dart
@@ -2,5 +2,5 @@ import 'package:defend_your_flame/constants/versioning_constants.dart';
 
 class ExperimentalConstants {
   // TODO post-beta release re-visit this
-  static const bool allowMoonClickFastTrack = VersioningConstants.isAlpha;
+  static const bool allowMoonMoneyCheat = VersioningConstants.isAlpha;
 }

--- a/lib/constants/translations/app_string_data.dart
+++ b/lib/constants/translations/app_string_data.dart
@@ -16,10 +16,14 @@ class AppStringData {
       'healthIndicatorAmount': '${AppStrings.placeholderText}/${AppStrings.placeholderText}',
 
       // Main menu
-      'startGame': 'Start Game',
-      'loadGame': 'Load Game',
+      'selectGame': 'Start A Game',
       'howToPlay': 'How To Play',
       'credits': 'Credits',
+
+      // Game selection
+      'startGame': 'Start Game',
+      'fastTrackTo': 'Fast Track To Round ${AppStrings.placeholderText}',
+      'loadGame': 'Load Game',
 
       // Shop
       'enterShop': "Enter Shop",

--- a/lib/constants/translations/app_strings.dart
+++ b/lib/constants/translations/app_strings.dart
@@ -63,10 +63,14 @@ class AppStrings {
   String get healthIndicatorText => getValue('healthIndicatorAmount');
 
   // Main menu
-  String get startGame => getValue('startGame');
-  String get loadGame => getValue('loadGame');
+  String get selectGame => getValue('selectGame');
   String get howToPlay => getValue('howToPlay');
   String get credits => getValue('credits');
+
+  // Game selection
+  String get startGame => getValue('startGame');
+  String get fastTrackTo => getValue('fastTrackTo');
+  String get loadGame => getValue('loadGame');
 
   // Between rounds
   String get startRound => getValue('startRound');

--- a/lib/constants/versioning_constants.dart
+++ b/lib/constants/versioning_constants.dart
@@ -9,7 +9,7 @@ class VersioningConstants {
 
   static const _majorVersion = 0;
   static const _minorVersion = 15;
-  static const _patchVersion = 0;
+  static const _patchVersion = 1;
 
   static const _releaseVersion = ReleaseVersion.alpha;
 

--- a/lib/core/flame/components/effects/text/damage_text.dart
+++ b/lib/core/flame/components/effects/text/damage_text.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:defend_your_flame/core/flame/components/effects/text/floating_text.dart';
 import 'package:defend_your_flame/core/flame/managers/text/text_manager.dart';
 import 'package:flame/components.dart';
@@ -7,7 +9,11 @@ import 'package:flutter/material.dart';
 class DamageText extends FloatingText {
   static final TextRenderer _damageTextRenderer = TextManager.customDefaultRenderer(fontSize: 10, color: Colors.red);
   DamageText(int damage) : super(textRenderer: _damageTextRenderer) {
-    scale = Vector2.all(1 + (damage / 16));
+    scale = Vector2.all(_scaleDamageText(damage));
     text = "-$damage";
+  }
+
+  double _scaleDamageText(int dmg) {
+    return 1 + (sqrt(dmg) / 6);
   }
 }

--- a/lib/core/flame/components/effects/text/floating_text.dart
+++ b/lib/core/flame/components/effects/text/floating_text.dart
@@ -3,19 +3,26 @@ import 'package:defend_your_flame/helpers/timestep/timestep_helper.dart';
 import 'package:flame/components.dart';
 
 class FloatingText extends TextComponent {
-  static const double speed = 0.5;
+  static const double speed = 30;
 
-  late Vector2 _velocity = Vector2((GlobalVars.rand.nextDouble() * speed) * (GlobalVars.rand.nextBool() ? 1 : -1),
-          -((GlobalVars.rand.nextDouble() * speed) + (1.5 * speed)).abs()) *
-      0.2;
+  late Vector2 _velocity = Vector2(
+    GlobalVars.rand.nextDouble() * 2 * speed - speed,
+    GlobalVars.rand.nextDouble() * 2 * speed - speed,
+  );
 
-  FloatingText({super.text, super.textRenderer}) : super();
+  double _timeAlive = 0;
+
+  FloatingText({super.text, super.textRenderer}) {
+    anchor = Anchor.center;
+  }
 
   @override
   void update(double dt) {
+    _timeAlive += dt;
     _velocity = TimestepHelper.multiplyVector2(_velocity, 0.95, dt);
-    position += _velocity;
-    var newScale = TimestepHelper.add(scale.x, -0.8, dt);
+    position = TimestepHelper.addVector2(position, _velocity, dt);
+
+    var newScale = TimestepHelper.add(scale.x, -0.7 - (_timeAlive * 2), dt);
     scale = Vector2.all(newScale);
 
     if (scale.x < 0.04) {

--- a/lib/core/flame/components/effects/text/gold_text.dart
+++ b/lib/core/flame/components/effects/text/gold_text.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:defend_your_flame/core/flame/components/effects/text/floating_text.dart';
 import 'package:defend_your_flame/core/flame/managers/text/text_manager.dart';
 import 'package:flame/extensions.dart';
@@ -6,9 +8,13 @@ import 'package:flutter/material.dart';
 
 class GoldText extends FloatingText {
   static final TextRenderer _goldTextRenderer =
-      TextManager.customDefaultRenderer(fontSize: 10, color: Colors.yellow.darken(0.2));
+      TextManager.customDefaultRenderer(fontSize: 10, color: Colors.yellow.darken(0.15));
   GoldText(int gold) : super(textRenderer: _goldTextRenderer) {
-    scale = Vector2.all(1 + (gold / 16));
+    scale = Vector2.all(_scaleGoldText(gold));
     text = "+$gold";
+  }
+
+  double _scaleGoldText(int gold) {
+    return 1 + (sqrt(gold) / 5);
   }
 }

--- a/lib/core/flame/components/entities/entity.dart
+++ b/lib/core/flame/components/entities/entity.dart
@@ -200,13 +200,12 @@ class Entity extends SpriteAnimationGroupComponent<EntityState>
 
   void fallingCalculation(double dt) {}
 
-  void takeDamage(double damage) {
+  void takeDamage(double damage, {Vector2? position}) {
     _currentHealth -= damage;
 
+    world.effectManager.addDamageText(damage.toInt(), position ?? trueCenter);
     if (_currentHealth <= MiscConstants.eps) {
       initiateDeath();
-    } else {
-      world.effectManager.addDamageText(damage.toInt(), trueCenter);
     }
   }
 
@@ -217,8 +216,7 @@ class Entity extends SpriteAnimationGroupComponent<EntityState>
 
       // Apply the bounding constraints to make sure the entity is in the correct position.
       _applyBoundingConstraints(0);
-      world.playerBase.mutateGold(entityConfig.goldOnKill);
-      world.effectManager.addGoldText(entityConfig.goldOnKill, trueCenter);
+      world.playerBase.mutateGold(entityConfig.goldOnKill, position: trueCenter);
 
       for (var hitbox in _hitboxes) {
         hitbox.collisionType = CollisionType.inactive;

--- a/lib/core/flame/components/entities/mobs/bosses/death_reaper.dart
+++ b/lib/core/flame/components/entities/mobs/bosses/death_reaper.dart
@@ -18,7 +18,7 @@ class DeathReaper extends Entity with DisappearOnDeath, HasDraggableCollisions, 
     defaultSize: Vector2(140, 93),
     defaultScale: 1.6,
     idleConfig: AnimationConfig(
-      stepTime: 0.21,
+      stepTime: 0.2,
       frames: 8,
     ),
     walkingConfig: AnimationConfig(
@@ -30,7 +30,7 @@ class DeathReaper extends Entity with DisappearOnDeath, HasDraggableCollisions, 
       frames: 10,
     ),
     dyingConfig: AnimationConfig(
-      stepTime: 0.18,
+      stepTime: 0.16,
       frames: 10,
     ),
     walkingForwardSpeed: 14,

--- a/lib/core/flame/components/entities/mobs/mage.dart
+++ b/lib/core/flame/components/entities/mobs/mage.dart
@@ -84,7 +84,7 @@ class Mage extends Entity with DisappearOnDeath, HasIdleTime, HasDraggableCollis
   @override
   void onTapDown(TapDownEvent event) {
     // Inflict damage on tap and make them idle if they were walking.
-    takeDamage(DamageConstants.clickingDamage);
+    takeDamage(DamageConstants.clickingDamage, position: event.localPosition + topLeftPosition);
 
     forceResetIdleTimer();
 

--- a/lib/core/flame/components/entities/mobs/strong_skeleton.dart
+++ b/lib/core/flame/components/entities/mobs/strong_skeleton.dart
@@ -32,7 +32,7 @@ class StrongSkeleton extends DraggableEntity with DisappearOnDeath {
 
   @override
   Vector2? attackEffectPosition() {
-    return position + scaledSize / 2;
+    return trueCenter + Vector2(scaledSize.x / 2 - 3, 0);
   }
 
   @override

--- a/lib/core/flame/components/environment/components/moon.dart
+++ b/lib/core/flame/components/environment/components/moon.dart
@@ -8,6 +8,7 @@ import 'package:flame/events.dart';
 import 'package:flutter/material.dart';
 
 class Moon extends PositionComponent with TapCallbacks, GestureHitboxes, HasWorldReference<MainWorld> {
+  static const double preRotationInDegrees = 12;
   final Paint _moonPaint = Paint()..color = Colors.white.withOpacity(0.4);
 
   final double _rotationalSpeed = MathHelper.degreesToRads(1);
@@ -20,7 +21,8 @@ class Moon extends PositionComponent with TapCallbacks, GestureHitboxes, HasWorl
 
   Moon() {
     // Pre-rotate it a tad
-    position = MathHelper.rotateAboutOrigin(_initialPosition, _rotateAround, MathHelper.degreesToRads(12));
+    position =
+        MathHelper.rotateAboutOrigin(_initialPosition, _rotateAround, MathHelper.degreesToRads(preRotationInDegrees));
   }
 
   @override
@@ -43,7 +45,7 @@ class Moon extends PositionComponent with TapCallbacks, GestureHitboxes, HasWorl
     position = MathHelper.rotateAboutOrigin(position, _rotateAround, toRotate);
 
     _totalRotated += MathHelper.radsToDegrees(toRotate);
-    if (_totalRotated > 170) {
+    if (_totalRotated > 180 - (preRotationInDegrees * 2)) {
       _totalRotated = 0;
       position = _initialPosition;
     }
@@ -55,8 +57,8 @@ class Moon extends PositionComponent with TapCallbacks, GestureHitboxes, HasWorl
   void onTapDown(TapDownEvent event) {
     super.onTapDown(event);
 
-    if (ExperimentalConstants.allowMoonClickFastTrack) {
-      world.moonClickFastTrack();
+    if (ExperimentalConstants.allowMoonMoneyCheat && world.worldStateManager.betweenRounds) {
+      world.playerBase.mutateGold(100, position: event.localPosition + position);
     }
   }
 }

--- a/lib/core/flame/components/hud/buttons/game_selection/fast_track_to_button.dart
+++ b/lib/core/flame/components/hud/buttons/game_selection/fast_track_to_button.dart
@@ -1,0 +1,22 @@
+import 'package:defend_your_flame/constants/translations/app_string_helper.dart';
+import 'package:defend_your_flame/core/flame/components/hud/base_components/default_button.dart';
+import 'package:defend_your_flame/core/flame/components/hud/game_selection_hud.dart';
+import 'package:flame/components.dart';
+
+class FastTrackToButton extends DefaultButton with ParentIsA<GameSelectionHud> {
+  final int round;
+  final int gold;
+
+  FastTrackToButton({required this.round, required this.gold}) : super();
+
+  @override
+  void onMount() {
+    text = AppStringHelper.insertNumber(game.appStrings.fastTrackTo, round);
+    super.onMount();
+  }
+
+  @override
+  void onPressed() {
+    parent.startGame(gold: gold, round: round);
+  }
+}

--- a/lib/core/flame/components/hud/buttons/game_selection/load_game_button.dart
+++ b/lib/core/flame/components/hud/buttons/game_selection/load_game_button.dart
@@ -1,8 +1,8 @@
 import 'package:defend_your_flame/core/flame/components/hud/base_components/default_button.dart';
-import 'package:defend_your_flame/core/flame/components/hud/main_menu_hud.dart';
+import 'package:defend_your_flame/core/flame/components/hud/game_selection_hud.dart';
 import 'package:flame/components.dart';
 
-class LoadGameButton extends DefaultButton with ParentIsA<MainMenuHud> {
+class LoadGameButton extends DefaultButton with ParentIsA<GameSelectionHud> {
   LoadGameButton() : super(comingSoon: true);
 
   @override

--- a/lib/core/flame/components/hud/buttons/game_selection/start_game_button.dart
+++ b/lib/core/flame/components/hud/buttons/game_selection/start_game_button.dart
@@ -1,0 +1,18 @@
+import 'package:defend_your_flame/core/flame/components/hud/base_components/default_button.dart';
+import 'package:defend_your_flame/core/flame/components/hud/game_selection_hud.dart';
+import 'package:flame/components.dart';
+
+class StartGameButton extends DefaultButton with ParentIsA<GameSelectionHud> {
+  StartGameButton() : super();
+
+  @override
+  void onMount() {
+    text = game.appStrings.startGame;
+    super.onMount();
+  }
+
+  @override
+  void onPressed() {
+    parent.startGame();
+  }
+}

--- a/lib/core/flame/components/hud/buttons/menu/select_game_button.dart
+++ b/lib/core/flame/components/hud/buttons/menu/select_game_button.dart
@@ -2,17 +2,17 @@ import 'package:defend_your_flame/core/flame/components/hud/base_components/defa
 import 'package:defend_your_flame/core/flame/components/hud/main_menu_hud.dart';
 import 'package:flame/components.dart';
 
-class StartGameButton extends DefaultButton with ParentIsA<MainMenuHud> {
-  StartGameButton() : super();
+class SelectGameButton extends DefaultButton with ParentIsA<MainMenuHud> {
+  SelectGameButton() : super();
 
   @override
   void onMount() {
-    text = game.appStrings.startGame;
+    text = game.appStrings.selectGame;
     super.onMount();
   }
 
   @override
   void onPressed() {
-    parent.startRound();
+    parent.goToGameSelection();
   }
 }

--- a/lib/core/flame/components/hud/game_over_hud.dart
+++ b/lib/core/flame/components/hud/game_over_hud.dart
@@ -6,6 +6,7 @@ import 'package:defend_your_flame/core/flame/components/hud/buttons/restart_game
 import 'package:defend_your_flame/core/flame/components/hud/text/game_over_text.dart';
 import 'package:defend_your_flame/core/flame/main_game.dart';
 import 'package:defend_your_flame/core/flame/managers/text/text_manager.dart';
+import 'package:defend_your_flame/core/flame/worlds/main_world_state.dart';
 import 'package:flame/components.dart';
 
 class GameOverHud extends BasicHud with HasGameReference<MainGame> {
@@ -40,6 +41,7 @@ class GameOverHud extends BasicHud with HasGameReference<MainGame> {
   }
 
   restartGame() {
-    world.roundManager.restartGame();
+    world.roundManager.resetGame();
+    world.worldStateManager.changeState(MainWorldState.gameSelection);
   }
 }

--- a/lib/core/flame/components/hud/game_selection_hud.dart
+++ b/lib/core/flame/components/hud/game_selection_hud.dart
@@ -1,0 +1,51 @@
+import 'dart:async';
+
+import 'package:defend_your_flame/constants/theming_constants.dart';
+import 'package:defend_your_flame/core/flame/components/hud/base_components/basic_hud.dart';
+import 'package:defend_your_flame/core/flame/components/hud/buttons/game_selection/fast_track_to_button.dart';
+import 'package:defend_your_flame/core/flame/components/hud/buttons/game_selection/start_game_button.dart';
+import 'package:defend_your_flame/core/flame/components/hud/buttons/go_back_button.dart';
+import 'package:defend_your_flame/core/flame/components/hud/buttons/game_selection/load_game_button.dart';
+import 'package:defend_your_flame/core/flame/worlds/main_world_state.dart';
+import 'package:flame/components.dart';
+
+class GameSelectionHud extends BasicHud {
+  late final StartGameButton _startGame = StartGameButton()
+    ..position = Vector2(world.worldWidth / 2, world.worldHeight / 3);
+
+  late final FastTrackToButton _fastTrackToTen = FastTrackToButton(round: 10, gold: 400)
+    ..position = _startGame.position + ThemingConstants.menuButtonGap;
+
+  late final FastTrackToButton _fastTrackToFifteen = FastTrackToButton(round: 15, gold: 800)
+    ..position = _fastTrackToTen.position + ThemingConstants.menuButtonGap;
+
+  late final LoadGameButton _loadGame = LoadGameButton()
+    ..position = _fastTrackToFifteen.position + ThemingConstants.menuButtonGap;
+
+  late final GoBackButton _goBackButton = GoBackButton(backFunction: () {
+    world.worldStateManager.changeState(MainWorldState.mainMenu);
+  })
+    ..position = _loadGame.position + ThemingConstants.menuButtonGap;
+
+  @override
+  FutureOr<void> onLoad() {
+    add(_startGame);
+    add(_fastTrackToTen);
+    add(_fastTrackToFifteen);
+    add(_loadGame);
+    add(_goBackButton);
+
+    return super.onLoad();
+  }
+
+  void startGame({int? round, int? gold}) {
+    if (round != null && gold != null) {
+      world.playerBase.mutateGold(gold);
+      world.roundManager.overrideRound(round - 1);
+
+      world.worldStateManager.changeState(MainWorldState.betweenRounds);
+    } else {
+      world.roundManager.startNextRound();
+    }
+  }
+}

--- a/lib/core/flame/components/hud/main_menu_hud.dart
+++ b/lib/core/flame/components/hud/main_menu_hud.dart
@@ -4,9 +4,9 @@ import 'package:defend_your_flame/constants/theming_constants.dart';
 import 'package:defend_your_flame/core/flame/components/hud/base_components/basic_hud.dart';
 import 'package:defend_your_flame/core/flame/components/hud/buttons/menu/credits_button.dart';
 import 'package:defend_your_flame/core/flame/components/hud/buttons/menu/how_to_play_button.dart';
-import 'package:defend_your_flame/core/flame/components/hud/buttons/menu/load_game_button.dart';
-import 'package:defend_your_flame/core/flame/components/hud/buttons/menu/start_game_button.dart';
+import 'package:defend_your_flame/core/flame/components/hud/buttons/menu/select_game_button.dart';
 import 'package:defend_your_flame/core/flame/components/hud/text/title_text.dart';
+import 'package:defend_your_flame/core/flame/worlds/main_world_state.dart';
 import 'package:flame/components.dart';
 
 class MainMenuHud extends BasicHud {
@@ -14,29 +14,25 @@ class MainMenuHud extends BasicHud {
     ..position = Vector2(world.worldWidth / 2, 80)
     ..anchor = Anchor.topCenter;
 
-  late final StartGameButton _startGame = StartGameButton()
-    ..position = Vector2(world.worldWidth / 2, world.worldHeight / 3);
-
-  late final LoadGameButton _loadGame = LoadGameButton()
-    ..position = _startGame.position + ThemingConstants.menuButtonGap;
+  late final SelectGameButton _selectGame = SelectGameButton()
+    ..position = Vector2(world.worldWidth / 2, world.worldHeight / 3 + 20);
 
   late final HowToPlayButton _howToPlay = HowToPlayButton()
-    ..position = _loadGame.position + ThemingConstants.menuButtonGap;
+    ..position = _selectGame.position + ThemingConstants.menuButtonGap;
 
   late final CreditsButton _credits = CreditsButton()..position = _howToPlay.position + ThemingConstants.menuButtonGap;
 
   @override
   FutureOr<void> onLoad() {
     add(_titleText);
-    add(_startGame);
-    add(_loadGame);
+    add(_selectGame);
     add(_howToPlay);
     add(_credits);
 
     return super.onLoad();
   }
 
-  void startRound() {
-    world.roundManager.startNextRound();
+  void goToGameSelection() {
+    world.worldStateManager.changeState(MainWorldState.gameSelection);
   }
 }

--- a/lib/core/flame/components/masonry/player_base.dart
+++ b/lib/core/flame/components/masonry/player_base.dart
@@ -66,7 +66,13 @@ class PlayerBase extends PositionComponent with HasWorldReference<MainWorld>, Ha
     _additionalComponents.clear();
   }
 
-  void mutateGold(int gold) => _gold += gold;
+  void mutateGold(int gold, {Vector2? position}) {
+    _gold += gold;
+
+    if (position != null) {
+      world.effectManager.addGoldText(gold, position);
+    }
+  }
 
   void takeDamage(int damage, {Vector2? position}) {
     _wall.takeDamage(damage, position: position);

--- a/lib/core/flame/components/masonry/player_base.dart
+++ b/lib/core/flame/components/masonry/player_base.dart
@@ -25,7 +25,7 @@ class PlayerBase extends PositionComponent with HasWorldReference<MainWorld>, Ha
   late final FirePit _firePit = FirePit()
     ..position = Vector2(Wall.wallAreaWidth + (baseWidthWithoutWall / 2) - 10, baseHeight / 2 - 10);
 
-  int _gold = DebugConstants.testShopLogic ? 5000 : 10000;
+  int _gold = DebugConstants.testShopLogic ? 5000 : 0;
 
   int get totalGold => _gold;
   bool get destroyed => _wall.health <= 0;

--- a/lib/core/flame/components/masonry/walls/wall_renderer.dart
+++ b/lib/core/flame/components/masonry/walls/wall_renderer.dart
@@ -35,7 +35,7 @@ class WallRenderer extends PositionComponent with ParentIsA<Wall>, Snapshot {
     _horizontalRange = _verticalRange * ParallaxConstants.horizontalDisplacementFactor;
     _horizontalDiffPerRender = _horizontalRange / _verticalRenders;
 
-    _xOffset = (parent.scaledSize.x - Wall.wallAreaWidth) / 2;
+    _xOffset = -25 - (parent.scaledSize.x - Wall.wallAreaWidth);
   }
 
   updateWallRenderValues() {

--- a/lib/core/flame/managers/entity_manager.dart
+++ b/lib/core/flame/managers/entity_manager.dart
@@ -119,7 +119,7 @@ class EntityManager extends Component with HasWorldReference<MainWorld> {
   }
 
   removeEntity(Entity entity) {
-    remove(entity);
+    entity.removeFromParent();
 
     var key = (entity.topLeftPosition.y + entity.scaledSize.y).toInt();
     if (_entities.containsKey(key) && _entities[key]!.contains(entity)) {
@@ -144,8 +144,14 @@ class EntityManager extends Component with HasWorldReference<MainWorld> {
   void clearEntities() {
     for (var entity in children) {
       if (entity is Entity) {
-        entity.removeFromParent();
+        removeEntity(entity);
       }
     }
+
+    _entities.clear();
+    _spawning = false;
+    _entitiesToSpawn.clear();
+    _timeCounter = 0;
+    _secondsToSpawnOver = 0;
   }
 }

--- a/lib/core/flame/managers/hud_manager.dart
+++ b/lib/core/flame/managers/hud_manager.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:defend_your_flame/core/flame/components/hud/base_components/basic_hud.dart';
 import 'package:defend_your_flame/core/flame/components/hud/game_over_hud.dart';
+import 'package:defend_your_flame/core/flame/components/hud/game_selection_hud.dart';
 import 'package:defend_your_flame/core/flame/components/hud/level_hud.dart';
 import 'package:defend_your_flame/core/flame/components/hud/main_menu_hud.dart';
 import 'package:defend_your_flame/core/flame/components/hud/next_round_hud.dart';
@@ -11,6 +12,7 @@ import 'package:flame/components.dart';
 
 class HudManager extends PositionComponent with HasWorldReference<MainWorld> {
   final MainMenuHud _mainMenuHud = MainMenuHud();
+  final GameSelectionHud _gameSelectionHud = GameSelectionHud();
   final LevelHud _levelHud = LevelHud();
   final NextRoundHud _nextRoundHud = NextRoundHud();
   final GameOverHud _gameOverHud = GameOverHud();
@@ -43,6 +45,9 @@ class HudManager extends PositionComponent with HasWorldReference<MainWorld> {
     switch (world.worldStateManager.currentState) {
       case MainWorldState.mainMenu:
         hudToShow = _mainMenuHud;
+        break;
+      case MainWorldState.gameSelection:
+        hudToShow = _gameSelectionHud;
         break;
       case MainWorldState.playing:
         hudToShow = _levelHud;

--- a/lib/core/flame/managers/round_manager.dart
+++ b/lib/core/flame/managers/round_manager.dart
@@ -12,13 +12,11 @@ class RoundManager extends Component with HasWorldReference<MainWorld> {
     world.entityManager.startSpawningRound();
   }
 
-  void restartGame() {
-    _currentRound = 0;
+  void resetGame() {
     world.playerBase.reset();
     world.entityManager.clearEntities();
     world.shopManager.resetPurchases();
-
-    startNextRound();
+    _currentRound = 0;
   }
 
   void overrideRound(int round) {

--- a/lib/core/flame/shop/defenses/attack_totem_purchase.dart
+++ b/lib/core/flame/shop/defenses/attack_totem_purchase.dart
@@ -1,16 +1,23 @@
+import 'dart:math';
+
 import 'package:defend_your_flame/constants/translations/app_strings.dart';
 import 'package:defend_your_flame/core/flame/shop/purchasable.dart';
 import 'package:defend_your_flame/core/flame/worlds/main_world.dart';
 
 class AttackTotemPurchase extends Purchasable {
   static const int maxTotems = 6;
+  static const double totemCostProgression = 1.25;
+  static const int initialCost = 120;
+
+  static final List<int> costs =
+      List<int>.generate(maxTotems, (i) => (10 * ((initialCost * pow(totemCostProgression, i)) / 10).ceil()));
 
   AttackTotemPurchase(AppStrings appStrings)
       : super(
           name: appStrings.attackTotemName,
           description: appStrings.attackTotemDescription,
           quote: appStrings.attackTotemQuote,
-          cost: [120, 150, 190, 240, 300, 360],
+          cost: costs,
           maxPurchaseCount: maxTotems,
         );
 

--- a/lib/core/flame/worlds/main_world.dart
+++ b/lib/core/flame/worlds/main_world.dart
@@ -9,7 +9,6 @@ import 'package:defend_your_flame/core/flame/managers/projectile_manager.dart';
 import 'package:defend_your_flame/core/flame/managers/round_manager.dart';
 import 'package:defend_your_flame/core/flame/managers/shop_manager.dart';
 import 'package:defend_your_flame/core/flame/managers/world_state_manager.dart';
-import 'package:defend_your_flame/core/flame/worlds/main_world_state.dart';
 import 'package:defend_your_flame/helpers/platform_helper.dart';
 import 'package:flame/components.dart';
 
@@ -62,17 +61,5 @@ class MainWorld extends World with HasCollisionDetection {
   _addNonVisualComponents() {
     add(_roundManager);
     add(_shopManager);
-  }
-
-  void moonClickFastTrack() {
-    // Only allow this to be used in the main menu.
-    if (_worldStateManager.currentState != MainWorldState.mainMenu) {
-      return;
-    }
-
-    // Advance to round 10, give gold, and go to the shop.
-    _worldStateManager.changeState(MainWorldState.betweenRounds);
-    _roundManager.overrideRound(9); // It's actually 9, because clicking next round will go to 10.
-    _playerBase.mutateGold(600);
   }
 }

--- a/lib/core/flame/worlds/main_world_state.dart
+++ b/lib/core/flame/worlds/main_world_state.dart
@@ -1,5 +1,6 @@
 enum MainWorldState {
   mainMenu,
+  gameSelection,
   playing,
   betweenRounds,
   gameOver,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:defend_your_flame/constants/constants.dart';
 import 'package:defend_your_flame/core/flame/game_provider.dart';
 import 'package:defend_your_flame/helpers/platform_helper.dart';
 import 'package:defend_your_flame/core/storage/game_data.dart';
@@ -7,8 +6,6 @@ import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
 import 'package:scoped_model/scoped_model.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html;
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -19,8 +16,6 @@ void main() async {
   if (PlatformHelper.isMobile) {
     await Flame.device.setLandscape();
     await Flame.device.fullScreen();
-  } else if (PlatformHelper.isWeb) {
-    html.document.title = Constants.gameTitle;
   }
 
   runApp(ScopedModel<GameData>(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:defend_your_flame/constants/constants.dart';
 import 'package:defend_your_flame/core/flame/game_provider.dart';
 import 'package:defend_your_flame/helpers/platform_helper.dart';
 import 'package:defend_your_flame/core/storage/game_data.dart';
@@ -6,6 +7,8 @@ import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
 import 'package:scoped_model/scoped_model.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html' as html;
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -16,6 +19,8 @@ void main() async {
   if (PlatformHelper.isMobile) {
     await Flame.device.setLandscape();
     await Flame.device.fullScreen();
+  } else if (PlatformHelper.isWeb) {
+    html.document.title = Constants.gameTitle;
   }
 
   runApp(ScopedModel<GameData>(

--- a/lib/states/state_manager.dart
+++ b/lib/states/state_manager.dart
@@ -1,3 +1,4 @@
+import 'package:defend_your_flame/constants/constants.dart';
 import 'package:defend_your_flame/constants/translations/app_strings.dart';
 import 'package:defend_your_flame/core/flame/game_provider.dart';
 import 'package:defend_your_flame/helpers/platform_helper.dart';
@@ -18,6 +19,7 @@ class _StateManagerState extends State<StateManager> with WidgetsBindingObserver
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+        title: Constants.gameTitle,
         debugShowCheckedModeBanner: false,
         localizationsDelegates: const [
           AppStringsDelegate(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: defend_your_flame
 description: Defend your castles flame from the enemy
 publish_to: 'none'
-version: 0.15.0+1 # +1 since we haven't actually published this yet
+version: 0.15.1+1 # +1 since we haven't actually published this yet
 
 environment:
   sdk: '>=3.1.2 <4.0.0'


### PR DESCRIPTION
From the changelog:

```
## 0.15.1 alpha - 13th May, 2024

### New Features
- N/A

### Bug Fixes
- Fixed gold starting at 10,000 - this is now correctly back at 0

### Improvements / Balances
- Overhauled the game start menu
  - There is now an additional screen for selecting a game
  - You can now fast track to round 10 or 15 with additional gold
- Removed the "moon-click" fast track in favour of the new game start menu
- Clicking the moon between rounds now gives gold, this is temporary for debugging purposes while testing in alpha
- Improved the visual effects of damage and gold
- Scaled the totem cost now to get progressively more expensive by 30% each time
- Small improvements to the positioning of the wall
- Small improvements to where damage text is positioned on mage and strong skeletons
```