### PR TITLE
Improve tip logic between rounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.15.2 alpha - 13th May, 2024
+
+### New Features
+- N/A
+
+### Bug Fixes
+- N/A
+
+### Improvements / Balances
+- Reduced gold per moon click to 50
+- Overhauled the tip system, now allowing for certain tips to always appear at certain rounds
+- Slightly improved the collision box of the strong skeleton
+
 ## 0.15.1 alpha - 13th May, 2024
 
 ### New Features

--- a/lib/constants/translations/app_string_constants.dart
+++ b/lib/constants/translations/app_string_constants.dart
@@ -1,4 +1,6 @@
 class AppStringConstants {
-  static const int amountOfTips = 7;
   static const String descriptionGap = '\n';
+
+  static const String gameTipPrefix = 'gameTip';
+  static const String roundTipDelimiter = "||";
 }

--- a/lib/constants/translations/app_string_data.dart
+++ b/lib/constants/translations/app_string_data.dart
@@ -1,4 +1,5 @@
 import 'package:defend_your_flame/constants/entity_spawn_constants.dart';
+import 'package:defend_your_flame/constants/translations/app_string_constants.dart';
 import 'package:defend_your_flame/constants/translations/app_string_helper.dart';
 import 'package:defend_your_flame/constants/translations/app_strings.dart';
 
@@ -37,15 +38,17 @@ class AppStringData {
       'noItemSelected': 'No item selected',
       'potentialPurchaseCount': '${AppStrings.placeholderText}/${AppStrings.placeholderText} purchased',
 
-      // Tips - if you modify tips make sure the tip amount constant in app_string_constants is correct.
-      'gameTip0': 'Injure flying enemies by throwing others into them or by tapping',
-      'gameTip1': 'Dimensia is a hidden gem of a game',
-      'gameTip2': 'Be careful of throwing enemies into your wall to avoid damaging it',
-      'gameTip3': 'Flying enemies can not be dragged, but they can be tapped and collided with',
-      'gameTip4': 'Ensure to use your gold to upgrade your defenses between rounds',
-      'gameTip5': 'Certain enemies are too heavy to pick up, slam other enemies into them!',
-      'gameTip6':
-          'The first boss round is at round ${EntitySpawnConstants.bossRounds.entries.first.key}, be prepared for a heavy enemy!',
+      // Tips
+      '${AppStringConstants.gameTipPrefix}0': 'Injure flying enemies by throwing others into them or by tapping',
+      '${AppStringConstants.gameTipPrefix}1': 'Dimensia is a hidden gem of a game',
+      '${AppStringConstants.gameTipPrefix}2': 'Be careful of throwing enemies into your wall to avoid damaging it',
+      '${AppStringConstants.gameTipPrefix}3':
+          'Flying enemies can not be dragged, but they can be tapped and collided with',
+      '${AppStringConstants.gameTipPrefix}4': 'Ensure to use your gold to upgrade your defenses between rounds',
+      '${AppStringConstants.gameTipPrefix}5': 'Certain enemies are too heavy to pick up, slam other enemies into them!',
+      '${AppStringConstants.gameTipPrefix}6': AppStringHelper.gameTipForRound(
+          EntitySpawnConstants.bossRounds.entries.first.key,
+          'The first boss round is up next, be prepared for a heavy enemy!'),
 
       // Purchasables
       'woodenWallName': 'Wooden Wall',

--- a/lib/constants/translations/app_string_helper.dart
+++ b/lib/constants/translations/app_string_helper.dart
@@ -11,6 +11,10 @@ class AppStringHelper {
     return description;
   }
 
+  static String gameTipForRound(int round, String tip) {
+    return '$round${AppStringConstants.roundTipDelimiter}$tip';
+  }
+
   static String insertNumber(String s, int n) => insertString(s, n.toString());
 
   static String insertString(String s, String n) {

--- a/lib/constants/translations/app_strings.dart
+++ b/lib/constants/translations/app_strings.dart
@@ -44,6 +44,10 @@ class AppStrings {
     return _cachedMap!;
   }
 
+  bool hasValue(String key) {
+    return localMap.containsKey(key) || AppStringData.values['en']!.containsKey(key);
+  }
+
   String getValue(String key) {
     var v = localMap[key];
     if (loc.languageCode != 'en' && (v == '' || v == null)) {
@@ -100,5 +104,22 @@ class AppStrings {
   String get stoneWallDescription => getValue('stoneWallDescription');
   String get stoneWallQuote => getValue('stoneWallQuote');
 
-  String getRandomTip() => getValue('gameTip${GlobalVars.rand.nextInt(AppStringConstants.amountOfTips)}');
+  late final List<String> _tips = [];
+  List<String> get tips {
+    if (_tips.isEmpty) {
+      int rollingFailure = 0;
+      for (var i = 0; i <= 100; i++) {
+        if (!hasValue('${AppStringConstants.gameTipPrefix}$i')) {
+          rollingFailure++;
+          if (rollingFailure > 4) break;
+          continue;
+        }
+        rollingFailure = 0;
+
+        _tips.add(getValue('${AppStringConstants.gameTipPrefix}$i'));
+      }
+    }
+
+    return _tips;
+  }
 }

--- a/lib/constants/versioning_constants.dart
+++ b/lib/constants/versioning_constants.dart
@@ -9,7 +9,7 @@ class VersioningConstants {
 
   static const _majorVersion = 0;
   static const _minorVersion = 15;
-  static const _patchVersion = 1;
+  static const _patchVersion = 2;
 
   static const _releaseVersion = ReleaseVersion.alpha;
 

--- a/lib/core/flame/components/entities/mobs/strong_skeleton.dart
+++ b/lib/core/flame/components/entities/mobs/strong_skeleton.dart
@@ -26,7 +26,7 @@ class StrongSkeleton extends DraggableEntity with DisappearOnDeath {
   );
 
   late final RectangleHitbox _hitbox =
-      EntityHelper.createRectangleHitbox(size: Vector2(24, 33), position: Vector2(30, 48), anchor: Anchor.bottomCenter);
+      EntityHelper.createRectangleHitbox(size: Vector2(24, 33), position: Vector2(32, 48), anchor: Anchor.bottomCenter);
 
   StrongSkeleton({super.scaleModifier}) : super(entityConfig: _strongSkeletonConfig);
 

--- a/lib/core/flame/components/environment/components/moon.dart
+++ b/lib/core/flame/components/environment/components/moon.dart
@@ -58,7 +58,7 @@ class Moon extends PositionComponent with TapCallbacks, GestureHitboxes, HasWorl
     super.onTapDown(event);
 
     if (ExperimentalConstants.allowMoonMoneyCheat && world.worldStateManager.betweenRounds) {
-      world.playerBase.mutateGold(100, position: event.localPosition + position);
+      world.playerBase.mutateGold(50, position: event.localPosition + position);
     }
   }
 }

--- a/lib/core/flame/components/hud/text/tip_text.dart
+++ b/lib/core/flame/components/hud/text/tip_text.dart
@@ -27,7 +27,7 @@ class TipText extends PositionComponent with HasWorldReference<MainWorld>, HasGa
   void update(double dt) {
     if (world.roundManager.currentRound != _currentRound) {
       _currentRound = world.roundManager.currentRound;
-      _setTip(game.appStrings.getRandomTip());
+      _setTip(game.gameTipManager.getTipForRound(_currentRound));
     }
 
     super.update(dt);

--- a/lib/core/flame/components/masonry/player_base.dart
+++ b/lib/core/flame/components/masonry/player_base.dart
@@ -18,7 +18,7 @@ class PlayerBase extends PositionComponent with HasWorldReference<MainWorld>, Ha
   static const double baseWidth = baseWidthWithoutWall + Wall.wallAreaWidth;
   static const double baseHeight = 180;
 
-  late final Rect _innerBaseRect = Rect.fromLTWH(Wall.wallAreaWidth + position.x, position.y + Wall.wallYOffset,
+  late final Rect _innerBaseRect = Rect.fromLTWH(position.x + (Wall.wallAreaWidth * 0.7), position.y + Wall.wallYOffset,
       width + BoundingConstants.maxXCoordinateOffScreen, baseHeight - (Wall.wallYOffset * 2));
 
   late final Wall _wall = Wall()..position = Vector2(0, Wall.wallYOffset);

--- a/lib/core/flame/main_game.dart
+++ b/lib/core/flame/main_game.dart
@@ -1,5 +1,6 @@
 import 'package:defend_your_flame/constants/constants.dart';
 import 'package:defend_your_flame/constants/translations/app_strings.dart';
+import 'package:defend_your_flame/core/flame/managers/game_tip_manager.dart';
 import 'package:defend_your_flame/core/flame/managers/sprite_manager.dart';
 import 'package:defend_your_flame/core/storage/game_data.dart';
 import 'package:flame/components.dart';
@@ -15,6 +16,8 @@ class MainGame extends FlameGame {
   // Given this game is within a fixed aspect ratio, this is a simple way to calculate the scaling factor of the games window.
   double get windowScale => windowWidth / Constants.desiredWidth;
 
+  late final GameTipManager _gameTipManager = GameTipManager(_appStrings.tips);
+
   // These are set in `setExternalDependencies`.
   // Is there a better way to do this?
   late AppStrings _appStrings;
@@ -22,6 +25,7 @@ class MainGame extends FlameGame {
 
   AppStrings get appStrings => _appStrings;
   GameData get gameData => _gameData;
+  GameTipManager get gameTipManager => _gameTipManager;
 
   MainGame({required World world, required CameraComponent camera}) : super(world: world, camera: camera);
 

--- a/lib/core/flame/managers/game_tip_manager.dart
+++ b/lib/core/flame/managers/game_tip_manager.dart
@@ -1,0 +1,38 @@
+import 'package:defend_your_flame/constants/translations/app_string_constants.dart';
+import 'package:defend_your_flame/helpers/misc_helper.dart';
+
+class GameTipManager {
+  final List<String> _genericTips = [];
+  final Map<int, List<String>> _roundTips = {};
+
+  GameTipManager(List<String> tips) {
+    _parseTips(tips);
+  }
+
+  void _parseTips(List<String> tips) {
+    for (var tip in tips) {
+      if (tip.contains(AppStringConstants.roundTipDelimiter)) {
+        var parts = tip.split(AppStringConstants.roundTipDelimiter);
+        var round = int.parse(parts[0]);
+        var tipContent = parts[1];
+
+        if (_roundTips.containsKey(round)) {
+          _roundTips[round]!.add(tipContent);
+        } else {
+          _roundTips[round] = [tipContent];
+        }
+      } else {
+        _genericTips.add(tip);
+      }
+    }
+  }
+
+  String getTipForRound(int currentRound) {
+    var nextRound = currentRound + 1;
+    if (_roundTips.containsKey(nextRound)) {
+      return MiscHelper.randomElement(_roundTips[nextRound]!);
+    }
+
+    return MiscHelper.randomElement(_genericTips);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: defend_your_flame
 description: Defend your castles flame from the enemy
 publish_to: 'none'
-version: 0.15.1+1 # +1 since we haven't actually published this yet
+version: 0.15.2+1 # +1 since we haven't actually published this yet
 
 environment:
   sdk: '>=3.1.2 <4.0.0'


### PR DESCRIPTION
From the changelog:

```
## 0.15.2 alpha - 13th May, 2024

### New Features
- N/A

### Bug Fixes
- N/A

### Improvements / Balances
- Reduced gold per moon click to 50
- Overhauled the tip system, now allowing for certain tips to always appear at certain rounds
- Slightly improved the collision box of the strong skeleton
```