### PR TITLE
Small physics and UX changes

### DIFF
--- a/lib/constants/versioning_constants.dart
+++ b/lib/constants/versioning_constants.dart
@@ -9,7 +9,7 @@ class VersioningConstants {
 
   static const _majorVersion = 0;
   static const _minorVersion = 17;
-  static const _patchVersion = 2;
+  static const _patchVersion = 3;
 
   static const _releaseVersion = ReleaseVersion.alpha;
 

--- a/lib/core/flame/components/entities/base_entity.dart
+++ b/lib/core/flame/components/entities/base_entity.dart
@@ -1,0 +1,32 @@
+import 'package:defend_your_flame/core/flame/components/entities/enums/entity_state.dart';
+import 'package:defend_your_flame/core/flame/components/entities/mixins/has_hitbox_positioning.dart';
+import 'package:defend_your_flame/core/flame/main_game.dart';
+import 'package:defend_your_flame/core/flame/managers/entity_manager.dart';
+import 'package:defend_your_flame/core/flame/mixins/has_wall_collision_detection.dart';
+import 'package:defend_your_flame/core/flame/worlds/main_world.dart';
+import 'package:flame/collisions.dart';
+import 'package:flame/components.dart';
+import 'package:flame/events.dart';
+
+abstract class BaseEntity extends SpriteAnimationGroupComponent<EntityState>
+    with
+        ParentIsA<EntityManager>,
+        HasWorldReference<MainWorld>,
+        HasGameReference<MainGame>,
+        HasVisibility,
+        TapCallbacks,
+        HasHitboxPositioning,
+        GestureHitboxes,
+        CollisionCallbacks,
+        HasWallCollisionDetection {
+  late Vector2 _startingPosition;
+
+  Vector2 get startPosition => _startingPosition;
+  Vector2 get trueCenter => absoluteCenterOfMainHitbox();
+
+  @override
+  void onMount() {
+    super.onMount();
+    _startingPosition = position.clone();
+  }
+}

--- a/lib/core/flame/components/entities/draggable_entity.dart
+++ b/lib/core/flame/components/entities/draggable_entity.dart
@@ -205,19 +205,11 @@ class DraggableEntity extends Entity with DragCallbacks, WallAsSolid {
   }
 
   @override
-  void wallCollisionCalculation(double dt) {
-    if (_beingDragged) {
-      if (DamageHelper.hasDragVelocityImpact(velocity: _velocity, considerHorizontal: true)) {
-        world.playerBase.takeDamage(DamageConstants.wallImpactDamage.toInt(), position: wallIntersectionPoints.first);
-        dragDamage();
-      }
+  void wallCollision(double dt) {
+    if (DamageHelper.hasCollisionVelocityImpact(velocity: _velocity)) {
+      world.playerBase.takeDamage(DamageConstants.wallImpactDamage.toInt(), position: trueCenter);
+      dragDamage();
     }
-
-    if (current == EntityState.falling && _contactingGround) {
-      hitGround();
-    }
-
-    super.wallCollisionCalculation(dt);
   }
 
   @override

--- a/lib/core/flame/components/entities/mixins/disappear_on_death.dart
+++ b/lib/core/flame/components/entities/mixins/disappear_on_death.dart
@@ -1,8 +1,10 @@
+import 'package:defend_your_flame/core/flame/components/entities/base_entity.dart';
 import 'package:defend_your_flame/core/flame/components/entities/entity.dart';
+import 'package:defend_your_flame/core/flame/components/entities/enums/entity_state.dart';
 import 'package:flame/effects.dart';
 import 'package:flutter/animation.dart';
 
-mixin DisappearOnDeath on Entity {
+mixin DisappearOnDeath on BaseEntity {
   bool _removingAnimation = false;
 
   // The speed at which the entity will disappear when it dies, higher values will make it disappear faster.
@@ -14,7 +16,7 @@ mixin DisappearOnDeath on Entity {
 
   @override
   void update(double dt) {
-    if (!super.isAlive && !_removingAnimation) {
+    if (current == EntityState.dying && !_removingAnimation) {
       _removingAnimation = true;
       add(OpacityEffect.by(
         -0.95,
@@ -24,7 +26,7 @@ mixin DisappearOnDeath on Entity {
         ),
       )..onComplete = () {
           isVisible = false;
-          world.entityManager.removeEntity(this);
+          world.entityManager.removeEntity(this as Entity);
         });
     }
 

--- a/lib/core/flame/components/entities/mobs/bosses/death_reaper.dart
+++ b/lib/core/flame/components/entities/mobs/bosses/death_reaper.dart
@@ -1,7 +1,6 @@
 import 'package:defend_your_flame/constants/damage_constants.dart';
 import 'package:defend_your_flame/core/flame/components/entities/configs/animation_config.dart';
 import 'package:defend_your_flame/core/flame/components/entities/configs/entity_config.dart';
-import 'package:defend_your_flame/core/flame/components/entities/disappear_on_death.dart';
 import 'package:defend_your_flame/core/flame/components/entities/entity.dart';
 import 'package:defend_your_flame/core/flame/components/entities/enums/idle_time.dart';
 import 'package:defend_your_flame/core/flame/components/entities/mixins/has_draggable_collisions.dart';
@@ -12,7 +11,7 @@ import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 import 'package:flutter/painting.dart';
 
-class DeathReaper extends Entity with DisappearOnDeath, HasDraggableCollisions, HasIdleTime {
+class DeathReaper extends Entity with HasDraggableCollisions, HasIdleTime {
   static final EntityConfig _deathReaperConfig = EntityConfig(
     entityResourceName: 'bosses/death_reaper',
     defaultSize: Vector2(140, 93),

--- a/lib/core/flame/components/entities/mobs/bosses/fire_beast.dart
+++ b/lib/core/flame/components/entities/mobs/bosses/fire_beast.dart
@@ -1,7 +1,6 @@
 import 'package:defend_your_flame/constants/damage_constants.dart';
 import 'package:defend_your_flame/core/flame/components/entities/configs/animation_config.dart';
 import 'package:defend_your_flame/core/flame/components/entities/configs/entity_config.dart';
-import 'package:defend_your_flame/core/flame/components/entities/disappear_on_death.dart';
 import 'package:defend_your_flame/core/flame/components/entities/entity.dart';
 import 'package:defend_your_flame/core/flame/components/entities/mixins/has_draggable_collisions.dart';
 import 'package:defend_your_flame/core/flame/helpers/entity_helper.dart';
@@ -10,7 +9,7 @@ import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 import 'package:flutter/painting.dart';
 
-class FireBeast extends Entity with DisappearOnDeath, HasDraggableCollisions {
+class FireBeast extends Entity with HasDraggableCollisions {
   static final EntityConfig _fireBeastConfig = EntityConfig(
     entityResourceName: 'bosses/fire_beast',
     defaultSize: Vector2(288, 160),

--- a/lib/core/flame/components/entities/mobs/ice_wolf.dart
+++ b/lib/core/flame/components/entities/mobs/ice_wolf.dart
@@ -1,5 +1,4 @@
 import 'package:defend_your_flame/core/flame/components/entities/configs/animation_config.dart';
-import 'package:defend_your_flame/core/flame/components/entities/disappear_on_death.dart';
 import 'package:defend_your_flame/core/flame/components/entities/draggable_entity.dart';
 import 'package:defend_your_flame/core/flame/components/entities/configs/entity_config.dart';
 import 'package:defend_your_flame/core/flame/helpers/entity_helper.dart';
@@ -7,7 +6,7 @@ import 'package:defend_your_flame/helpers/misc_helper.dart';
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 
-class IceWolf extends DraggableEntity with DisappearOnDeath {
+class IceWolf extends DraggableEntity {
   static final EntityConfig _iceWolf = EntityConfig(
     entityResourceName: 'ice_wolf',
     defaultSize: Vector2(64, 48),

--- a/lib/core/flame/components/entities/mobs/mage.dart
+++ b/lib/core/flame/components/entities/mobs/mage.dart
@@ -1,7 +1,6 @@
 import 'package:defend_your_flame/constants/damage_constants.dart';
 import 'package:defend_your_flame/core/flame/components/entities/configs/animation_config.dart';
 import 'package:defend_your_flame/core/flame/components/entities/configs/entity_config.dart';
-import 'package:defend_your_flame/core/flame/components/entities/disappear_on_death.dart';
 import 'package:defend_your_flame/core/flame/components/entities/entity.dart';
 import 'package:defend_your_flame/core/flame/components/entities/enums/entity_state.dart';
 import 'package:defend_your_flame/core/flame/components/entities/enums/idle_time.dart';
@@ -16,7 +15,7 @@ import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flutter/painting.dart';
 
-class Mage extends Entity with DisappearOnDeath, HasIdleTime, HasDraggableCollisions {
+class Mage extends Entity with HasIdleTime, HasDraggableCollisions {
   static final EntityConfig _mageConfig = EntityConfig(
     entityResourceName: 'mage',
     defaultSize: Vector2(160, 128),

--- a/lib/core/flame/components/entities/mobs/rat.dart
+++ b/lib/core/flame/components/entities/mobs/rat.dart
@@ -1,5 +1,4 @@
 import 'package:defend_your_flame/core/flame/components/entities/configs/animation_config.dart';
-import 'package:defend_your_flame/core/flame/components/entities/disappear_on_death.dart';
 import 'package:defend_your_flame/core/flame/components/entities/draggable_entity.dart';
 import 'package:defend_your_flame/core/flame/components/entities/configs/entity_config.dart';
 import 'package:defend_your_flame/core/flame/helpers/entity_helper.dart';
@@ -7,7 +6,7 @@ import 'package:defend_your_flame/helpers/misc_helper.dart';
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 
-class Rat extends DraggableEntity with DisappearOnDeath {
+class Rat extends DraggableEntity {
   static final EntityConfig _ratConfig = EntityConfig(
     entityResourceName: 'rat',
     defaultSize: Vector2(32, 32),

--- a/lib/core/flame/components/entities/mobs/rock_golem.dart
+++ b/lib/core/flame/components/entities/mobs/rock_golem.dart
@@ -1,6 +1,5 @@
 import 'package:defend_your_flame/constants/damage_constants.dart';
 import 'package:defend_your_flame/core/flame/components/entities/configs/animation_config.dart';
-import 'package:defend_your_flame/core/flame/components/entities/disappear_on_death.dart';
 import 'package:defend_your_flame/core/flame/components/entities/draggable_entity.dart';
 import 'package:defend_your_flame/core/flame/components/entities/configs/entity_config.dart';
 import 'package:defend_your_flame/core/flame/components/entities/enums/idle_time.dart';
@@ -11,7 +10,7 @@ import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 import 'package:flutter/rendering.dart';
 
-class RockGolem extends DraggableEntity with DisappearOnDeath, HasIdleTime {
+class RockGolem extends DraggableEntity with HasIdleTime {
   static final EntityConfig _rockGolemConfig = EntityConfig(
     entityResourceName: 'rock_golem',
     defaultSize: Vector2(90, 64),

--- a/lib/core/flame/components/entities/mobs/skeleton.dart
+++ b/lib/core/flame/components/entities/mobs/skeleton.dart
@@ -1,5 +1,4 @@
 import 'package:defend_your_flame/core/flame/components/entities/configs/animation_config.dart';
-import 'package:defend_your_flame/core/flame/components/entities/disappear_on_death.dart';
 import 'package:defend_your_flame/core/flame/components/entities/draggable_entity.dart';
 import 'package:defend_your_flame/core/flame/components/entities/configs/entity_config.dart';
 import 'package:defend_your_flame/core/flame/helpers/entity_helper.dart';
@@ -7,7 +6,7 @@ import 'package:defend_your_flame/helpers/misc_helper.dart';
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 
-class Skeleton extends DraggableEntity with DisappearOnDeath {
+class Skeleton extends DraggableEntity {
   static final EntityConfig _skeletonConfig = EntityConfig(
     entityResourceName: 'skeleton',
     defaultSize: Vector2(22, 33),

--- a/lib/core/flame/components/entities/mobs/slime.dart
+++ b/lib/core/flame/components/entities/mobs/slime.dart
@@ -1,5 +1,4 @@
 import 'package:defend_your_flame/core/flame/components/entities/configs/animation_config.dart';
-import 'package:defend_your_flame/core/flame/components/entities/disappear_on_death.dart';
 import 'package:defend_your_flame/core/flame/components/entities/draggable_entity.dart';
 import 'package:defend_your_flame/core/flame/components/entities/configs/entity_config.dart';
 import 'package:defend_your_flame/core/flame/helpers/entity_helper.dart';
@@ -7,7 +6,7 @@ import 'package:defend_your_flame/helpers/misc_helper.dart';
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 
-class Slime extends DraggableEntity with DisappearOnDeath {
+class Slime extends DraggableEntity {
   static final EntityConfig _slimeConfig = EntityConfig(
     entityResourceName: 'slime',
     defaultSize: Vector2(34, 27),

--- a/lib/core/flame/components/entities/mobs/strong_skeleton.dart
+++ b/lib/core/flame/components/entities/mobs/strong_skeleton.dart
@@ -1,6 +1,5 @@
 import 'package:defend_your_flame/constants/damage_constants.dart';
 import 'package:defend_your_flame/core/flame/components/entities/configs/animation_config.dart';
-import 'package:defend_your_flame/core/flame/components/entities/disappear_on_death.dart';
 import 'package:defend_your_flame/core/flame/components/entities/draggable_entity.dart';
 import 'package:defend_your_flame/core/flame/components/entities/configs/entity_config.dart';
 import 'package:defend_your_flame/core/flame/helpers/entity_helper.dart';
@@ -9,7 +8,7 @@ import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 import 'package:flutter/rendering.dart';
 
-class StrongSkeleton extends DraggableEntity with DisappearOnDeath {
+class StrongSkeleton extends DraggableEntity {
   static final EntityConfig _strongSkeletonConfig = EntityConfig(
     entityResourceName: 'strong_skeleton',
     defaultSize: Vector2(64, 64),

--- a/lib/core/flame/components/hud/buttons/shop/shop_item_button.dart
+++ b/lib/core/flame/components/hud/buttons/shop/shop_item_button.dart
@@ -2,11 +2,11 @@ import 'package:defend_your_flame/core/flame/components/hud/base_components/text
 import 'package:defend_your_flame/core/flame/components/hud/shop/main_shop_hud.dart';
 import 'package:defend_your_flame/core/flame/components/hud/shop/shop_item_list.dart';
 import 'package:defend_your_flame/core/flame/managers/text/shop_text_manager.dart';
-import 'package:defend_your_flame/core/flame/shop/purchasable.dart';
+import 'package:defend_your_flame/core/flame/shop/purchaseable.dart';
 import 'package:flame/components.dart';
 
 class ShopItemButton extends TextButton with ParentIsA<ShopItemList>, HasAncestor<MainShopHud> {
-  final Purchasable purchasable;
+  final Purchaseable purchasable;
 
   ShopItemButton(this.purchasable)
       : super(

--- a/lib/core/flame/components/hud/game_selection_hud.dart
+++ b/lib/core/flame/components/hud/game_selection_hud.dart
@@ -13,10 +13,10 @@ class GameSelectionHud extends BasicHud {
   late final StartGameButton _startGame = StartGameButton()
     ..position = Vector2(world.worldWidth / 2, world.worldHeight / 3);
 
-  late final FastTrackToButton _fastTrackToTen = FastTrackToButton(round: 10, gold: 400)
+  late final FastTrackToButton _fastTrackToTen = FastTrackToButton(round: 10, gold: 460)
     ..position = _startGame.position + ThemingConstants.menuButtonGap;
 
-  late final FastTrackToButton _fastTrackToFifteen = FastTrackToButton(round: 15, gold: 800)
+  late final FastTrackToButton _fastTrackToFifteen = FastTrackToButton(round: 15, gold: 900)
     ..position = _fastTrackToTen.position + ThemingConstants.menuButtonGap;
 
   late final LoadGameButton _loadGame = LoadGameButton()

--- a/lib/core/flame/components/hud/main_menu_hud.dart
+++ b/lib/core/flame/components/hud/main_menu_hud.dart
@@ -6,6 +6,7 @@ import 'package:defend_your_flame/core/flame/components/hud/buttons/menu/credits
 import 'package:defend_your_flame/core/flame/components/hud/buttons/menu/how_to_play_button.dart';
 import 'package:defend_your_flame/core/flame/components/hud/buttons/menu/select_game_button.dart';
 import 'package:defend_your_flame/core/flame/components/hud/text/title_text.dart';
+import 'package:defend_your_flame/core/flame/components/hud/text/version_text.dart';
 import 'package:defend_your_flame/core/flame/worlds/main_world_state.dart';
 import 'package:flame/components.dart';
 
@@ -22,12 +23,18 @@ class MainMenuHud extends BasicHud {
 
   late final CreditsButton _credits = CreditsButton()..position = _howToPlay.position + ThemingConstants.menuButtonGap;
 
+  late final VersionText _versionText = VersionText()
+    ..position = _credits.position + ThemingConstants.menuButtonGap / 1.5
+    ..scale = Vector2.all(0.7)
+    ..anchor = Anchor.center;
+
   @override
   FutureOr<void> onLoad() {
     add(_titleText);
     add(_selectGame);
     add(_howToPlay);
     add(_credits);
+    add(_versionText);
 
     return super.onLoad();
   }

--- a/lib/core/flame/components/hud/shop/main_shop_hud.dart
+++ b/lib/core/flame/components/hud/shop/main_shop_hud.dart
@@ -10,7 +10,7 @@ import 'package:defend_your_flame/core/flame/components/hud/sprite_with_texts/go
 import 'package:defend_your_flame/core/flame/components/hud/sprite_with_texts/health_indicator.dart';
 import 'package:defend_your_flame/core/flame/components/hud/text/shop/no_item_selected_text.dart';
 import 'package:defend_your_flame/core/flame/components/hud/text/shop/shop_title_text.dart';
-import 'package:defend_your_flame/core/flame/shop/purchasable.dart';
+import 'package:defend_your_flame/core/flame/shop/purchaseable.dart';
 import 'package:flame/components.dart';
 import 'package:flame/image_composition.dart';
 
@@ -108,7 +108,7 @@ class MainShopHud extends BasicHud with ParentIsA<NextRoundHud> {
     parent.changeState(NextRoundHudState.menu);
   }
 
-  void showItemDescription(Purchasable purchasable) {
+  void showItemDescription(Purchaseable purchasable) {
     _noItemSelectedText.isVisible = false;
     add(_shopItemDescription);
 

--- a/lib/core/flame/components/hud/shop/shop_item_description.dart
+++ b/lib/core/flame/components/hud/shop/shop_item_description.dart
@@ -7,14 +7,14 @@ import 'package:defend_your_flame/core/flame/components/hud/text/shop/item_title
 import 'package:defend_your_flame/core/flame/main_game.dart';
 import 'package:defend_your_flame/core/flame/managers/text/text_manager.dart';
 import 'package:defend_your_flame/core/flame/worlds/main_world.dart';
-import 'package:defend_your_flame/core/flame/shop/purchasable.dart';
+import 'package:defend_your_flame/core/flame/shop/purchaseable.dart';
 import 'package:flame/components.dart';
 
 class ShopItemDescription extends PositionComponent
     with ParentIsA<MainShopHud>, HasWorldReference<MainWorld>, HasGameReference<MainGame> {
   static const double padding = 20;
   static final Vector2 _itemGap = Vector2(0, 35);
-  Purchasable? _selectedItem;
+  Purchaseable? _selectedItem;
 
   late final ItemTitle _itemTitle = ItemTitle()..position = Vector2(padding, padding);
 
@@ -57,7 +57,7 @@ class ShopItemDescription extends PositionComponent
     return super.onLoad();
   }
 
-  void itemSelected(Purchasable? selectedItem) {
+  void itemSelected(Purchaseable? selectedItem) {
     _selectedItem = selectedItem;
 
     _itemTitle.updateText(_selectedItem?.name ?? '');
@@ -69,8 +69,8 @@ class ShopItemDescription extends PositionComponent
   }
 
   void tryToBuy() {
-    if (_purchasePossible) {
-      world.shopManager.handlePurchase(_selectedItem!);
+    if (_purchasePossible && _selectedItem != null) {
+      world.shopManager.handlePurchase(_selectedItem!.type);
       _updateUx();
       parent.refreshShopList();
     }

--- a/lib/core/flame/components/hud/shop/shop_item_list.dart
+++ b/lib/core/flame/components/hud/shop/shop_item_list.dart
@@ -41,7 +41,7 @@ class ShopItemList extends PositionComponent with ParentIsA<MainShopHud>, HasWor
     _dividers.clear();
 
     var visiblePurchases =
-        world.shopManager.purchasables.where((p) => p.shouldBeVisible(world.shopManager.purchasables)).toList();
+        world.shopManager.purchasables.where((p) => p.shouldBeVisible(world.shopManager.purchased)).toList();
 
     var rollingButtonPosition = Vector2(size.x / 2, shopItemHeight / 2 + padding);
     var gap = Vector2(0, shopItemHeight + padding);

--- a/lib/core/flame/components/projectiles/curving_magic_projectile.dart
+++ b/lib/core/flame/components/projectiles/curving_magic_projectile.dart
@@ -10,7 +10,7 @@ import 'package:defend_your_flame/constants/bounding_constants.dart';
 import 'package:defend_your_flame/constants/physics_constants.dart';
 import 'package:defend_your_flame/core/flame/components/effects/particles/trailing_particles.dart';
 import 'package:defend_your_flame/core/flame/components/entities/mixins/has_entity_collisions.dart';
-import 'package:defend_your_flame/core/flame/mixins/has_wall_collision.dart';
+import 'package:defend_your_flame/core/flame/mixins/has_wall_collision_detection.dart';
 import 'package:defend_your_flame/core/flame/worlds/main_world.dart';
 import 'package:defend_your_flame/helpers/physics_helper.dart';
 import 'package:defend_your_flame/helpers/timestep/timestep_helper.dart';
@@ -19,7 +19,7 @@ import 'package:flame/components.dart';
 import 'package:flutter/material.dart';
 
 class CurvingMagicProjectile extends PositionComponent
-    with CollisionCallbacks, HasWallCollision, HasEntityCollisions, HasWorldReference<MainWorld> {
+    with CollisionCallbacks, HasWallCollisionDetection, HasEntityCollisions, HasWorldReference<MainWorld> {
   static const double removalYThreshold = 15;
 
   final Vector2 initialPosition;

--- a/lib/core/flame/managers/shop_manager.dart
+++ b/lib/core/flame/managers/shop_manager.dart
@@ -1,37 +1,43 @@
 import 'package:defend_your_flame/core/flame/main_game.dart';
 import 'package:defend_your_flame/core/flame/shop/defenses/attack_totem_purchase.dart';
 import 'package:defend_your_flame/core/flame/shop/npcs/blacksmith_purchase.dart';
+import 'package:defend_your_flame/core/flame/shop/purchaseable_type.dart';
 import 'package:defend_your_flame/core/flame/shop/walls/wooden_wall_purchase.dart';
 import 'package:defend_your_flame/core/flame/worlds/main_world.dart';
-import 'package:defend_your_flame/core/flame/shop/purchasable.dart';
+import 'package:defend_your_flame/core/flame/shop/purchaseable.dart';
 import 'package:defend_your_flame/core/flame/shop/walls/stone_wall_purchase.dart';
 import 'package:flame/components.dart';
 
 class ShopManager extends Component with HasWorldReference<MainWorld>, HasGameReference<MainGame> {
-  late final List<Purchasable> _purchasables = [
-    WoodenWallPurchase(game.appStrings),
-    StoneWallPurchase(game.appStrings),
-    AttackTotemPurchase(game.appStrings),
-    BlacksmithPurchase(game.appStrings),
-  ];
+  late final Map<PurchaseableType, Purchaseable> _purchasables = {
+    PurchaseableType.woodenWall: WoodenWallPurchase(game.appStrings),
+    PurchaseableType.stoneWall: StoneWallPurchase(game.appStrings),
+    PurchaseableType.attackTotem: AttackTotemPurchase(game.appStrings),
+    PurchaseableType.blacksmith: BlacksmithPurchase(game.appStrings),
+  };
 
-  List<Purchasable> get purchasables => _purchasables;
+  Set<PurchaseableType> _purchased = {};
 
-  // TODO this is super hacky but it's a quick fix to test this NPC for now, re-visit
-  bool get blacksmithPurchased => _purchasables[3].purchasedMaxAmount;
+  Iterable<Purchaseable> get purchasables => _purchasables.values;
+  Set<PurchaseableType> get purchased => _purchased;
 
-  void handlePurchase(Purchasable purchasable) {
-    var purchaseIndex = _purchasables.indexWhere((element) => element == purchasable);
-    if (_purchasables[purchaseIndex].purchasedMaxAmount || world.playerBase.totalGold < purchasable.currentCost) {
+  bool get blacksmithPurchased => _purchasables[PurchaseableType.blacksmith]!.purchasedMaxAmount;
+
+  void handlePurchase(PurchaseableType type) {
+    var purchase = _purchasables[type]!;
+    if (purchase.purchasedMaxAmount || world.playerBase.totalGold < purchase.currentCost) {
       return;
     }
 
-    world.playerBase.mutateGold(-purchasable.currentCost);
-    _purchasables[purchaseIndex].purchase(world);
+    world.playerBase.mutateGold(-purchase.currentCost);
+    purchase.purchase(world);
+    _purchased.add(type);
   }
 
   void resetPurchases() {
-    for (var element in _purchasables) {
+    _purchased.clear();
+
+    for (var element in _purchasables.values) {
       element.reset();
     }
   }

--- a/lib/core/flame/mixins/has_wall_collision_detection.dart
+++ b/lib/core/flame/mixins/has_wall_collision_detection.dart
@@ -2,7 +2,7 @@ import 'package:defend_your_flame/core/flame/components/masonry/walls/wall.dart'
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 
-mixin HasWallCollision on PositionComponent, CollisionCallbacks {
+mixin HasWallCollisionDetection on PositionComponent, CollisionCallbacks {
   bool _isCollidingWithWall = false;
 
   Set<Vector2> _wallIntersectionPoints = {};

--- a/lib/core/flame/shop/defenses/attack_totem_purchase.dart
+++ b/lib/core/flame/shop/defenses/attack_totem_purchase.dart
@@ -1,10 +1,11 @@
 import 'dart:math';
 
 import 'package:defend_your_flame/constants/translations/app_strings.dart';
-import 'package:defend_your_flame/core/flame/shop/purchasable.dart';
+import 'package:defend_your_flame/core/flame/shop/purchaseable.dart';
+import 'package:defend_your_flame/core/flame/shop/purchaseable_type.dart';
 import 'package:defend_your_flame/core/flame/worlds/main_world.dart';
 
-class AttackTotemPurchase extends Purchasable {
+class AttackTotemPurchase extends Purchaseable {
   static const int maxTotems = 6;
   static const double totemCostProgression = 1.25;
   static const int initialCost = 120;
@@ -14,6 +15,7 @@ class AttackTotemPurchase extends Purchasable {
 
   AttackTotemPurchase(AppStrings appStrings)
       : super(
+          type: PurchaseableType.attackTotem,
           name: appStrings.attackTotemName,
           description: appStrings.attackTotemDescription,
           quote: appStrings.attackTotemQuote,

--- a/lib/core/flame/shop/npcs/blacksmith_purchase.dart
+++ b/lib/core/flame/shop/npcs/blacksmith_purchase.dart
@@ -1,12 +1,14 @@
 import 'package:defend_your_flame/constants/translations/app_string_helper.dart';
 import 'package:defend_your_flame/constants/translations/app_strings.dart';
 import 'package:defend_your_flame/core/flame/components/entities/npcs/blacksmith.dart';
-import 'package:defend_your_flame/core/flame/shop/purchasable.dart';
+import 'package:defend_your_flame/core/flame/shop/purchaseable.dart';
+import 'package:defend_your_flame/core/flame/shop/purchaseable_type.dart';
 import 'package:defend_your_flame/core/flame/worlds/main_world.dart';
 
-class BlacksmithPurchase extends Purchasable {
+class BlacksmithPurchase extends Purchaseable {
   BlacksmithPurchase(AppStrings appStrings)
       : super(
+          type: PurchaseableType.blacksmith,
           name: appStrings.blacksmithName,
           description:
               AppStringHelper.insertNumber(appStrings.blacksmithDescription, Blacksmith.percentageOfWallHealthToRepair),

--- a/lib/core/flame/shop/purchaseable.dart
+++ b/lib/core/flame/shop/purchaseable.dart
@@ -1,7 +1,10 @@
+import 'package:defend_your_flame/core/flame/shop/purchaseable_type.dart';
 import 'package:defend_your_flame/core/flame/worlds/main_world.dart';
 
-abstract class Purchasable {
-  final Set<Type> dependencies;
+abstract class Purchaseable {
+  final Set<PurchaseableType> dependencies;
+
+  final PurchaseableType type;
 
   final String name;
   final String description;
@@ -18,8 +21,9 @@ abstract class Purchasable {
 
   int get currentCost => _purchaseCount >= cost.length ? cost.last : cost[_purchaseCount];
 
-  Purchasable(
-      {required this.name,
+  Purchaseable(
+      {required this.type,
+      required this.name,
       required this.description,
       required this.quote,
       required this.cost,
@@ -31,15 +35,12 @@ abstract class Purchasable {
     _purchaseCount++;
   }
 
-  // TODO post-beta release: re-consider this logic, feels hacky and also not the most efficient.
-  bool shouldBeVisible(List<Purchasable> purchasables) {
+  bool shouldBeVisible(Set<PurchaseableType> purchased) {
     if (dependencies.isEmpty) {
       return true;
     }
 
-    return purchasables
-        .where((element) => dependencies.contains(element.runtimeType))
-        .every((element) => element.purchasedAnyAmount);
+    return dependencies.every((element) => purchased.contains(element));
   }
 
   void reset() {

--- a/lib/core/flame/shop/purchaseable_type.dart
+++ b/lib/core/flame/shop/purchaseable_type.dart
@@ -1,0 +1,6 @@
+enum PurchaseableType {
+  woodenWall,
+  stoneWall,
+  attackTotem,
+  blacksmith,
+}

--- a/lib/core/flame/shop/walls/stone_wall_purchase.dart
+++ b/lib/core/flame/shop/walls/stone_wall_purchase.dart
@@ -2,13 +2,14 @@ import 'package:defend_your_flame/constants/translations/app_string_helper.dart'
 import 'package:defend_your_flame/constants/translations/app_strings.dart';
 import 'package:defend_your_flame/core/flame/components/masonry/walls/wall_helper.dart';
 import 'package:defend_your_flame/core/flame/components/masonry/walls/wall_type.dart';
-import 'package:defend_your_flame/core/flame/shop/purchasable.dart';
-import 'package:defend_your_flame/core/flame/shop/walls/wooden_wall_purchase.dart';
+import 'package:defend_your_flame/core/flame/shop/purchaseable.dart';
+import 'package:defend_your_flame/core/flame/shop/purchaseable_type.dart';
 import 'package:defend_your_flame/core/flame/worlds/main_world.dart';
 
-class StoneWallPurchase extends Purchasable {
+class StoneWallPurchase extends Purchaseable {
   StoneWallPurchase(AppStrings appStrings)
       : super(
+          type: PurchaseableType.stoneWall,
           name: appStrings.stoneWallName,
           description: AppStringHelper.insertNumbers(appStrings.stoneWallDescription, [
             WallHelper.totalHealth(WallType.stone) - WallHelper.totalHealth(WallType.wood),
@@ -16,7 +17,7 @@ class StoneWallPurchase extends Purchasable {
           ]),
           quote: appStrings.stoneWallQuote,
           cost: [320],
-          dependencies: {WoodenWallPurchase},
+          dependencies: {PurchaseableType.woodenWall},
         );
 
   @override

--- a/lib/core/flame/shop/walls/wooden_wall_purchase.dart
+++ b/lib/core/flame/shop/walls/wooden_wall_purchase.dart
@@ -2,12 +2,14 @@ import 'package:defend_your_flame/constants/translations/app_string_helper.dart'
 import 'package:defend_your_flame/constants/translations/app_strings.dart';
 import 'package:defend_your_flame/core/flame/components/masonry/walls/wall_helper.dart';
 import 'package:defend_your_flame/core/flame/components/masonry/walls/wall_type.dart';
-import 'package:defend_your_flame/core/flame/shop/purchasable.dart';
+import 'package:defend_your_flame/core/flame/shop/purchaseable.dart';
+import 'package:defend_your_flame/core/flame/shop/purchaseable_type.dart';
 import 'package:defend_your_flame/core/flame/worlds/main_world.dart';
 
-class WoodenWallPurchase extends Purchasable {
+class WoodenWallPurchase extends Purchaseable {
   WoodenWallPurchase(AppStrings appStrings)
       : super(
+          type: PurchaseableType.woodenWall,
           name: appStrings.woodenWallName,
           description: AppStringHelper.insertNumbers(appStrings.woodenWallDescription, [
             WallHelper.totalHealth(WallType.wood) - WallHelper.totalHealth(WallType.barricade),

--- a/lib/widgets/platform_wrappers/web_wrapper.dart
+++ b/lib/widgets/platform_wrappers/web_wrapper.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:defend_your_flame/constants/constants.dart';
 import 'package:defend_your_flame/constants/platform_constants.dart';
 import 'package:flutter/material.dart';
@@ -8,7 +10,7 @@ class WebWrapper extends StatefulWidget {
   static const double maxWebWidth = Constants.desiredWidth * webMaxDimensionFactor;
   static const double maxWebHeight = Constants.desiredHeight * webMaxDimensionFactor;
 
-  static const double borderPadding = 25;
+  static const double topPadding = 40;
 
   final Widget child;
 
@@ -21,6 +23,10 @@ class WebWrapper extends StatefulWidget {
 class WebWrapperState extends State<WebWrapper> {
   @override
   Widget build(BuildContext context) {
+    var windowSize = MediaQuery.of(context).size;
+    var trueTopPadding =
+        max(min(WebWrapper.topPadding, (windowSize.height - WebWrapper.maxWebHeight) / 2), 0).toDouble();
+
     return SingleChildScrollView(
       child: Column(
         children: [
@@ -32,7 +38,7 @@ class WebWrapperState extends State<WebWrapper> {
                 maxHeight: WebWrapper.maxWebHeight,
               ),
               child: Container(
-                padding: const EdgeInsets.all(WebWrapper.borderPadding),
+                padding: EdgeInsets.only(top: trueTopPadding),
                 child: AspectRatio(
                   aspectRatio: Constants.desiredAspectRatio,
                   child: Container(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: defend_your_flame
-description: Defend your castles flame from the enemy
+description: Defend your flame from the enemy
 publish_to: 'none'
 version: 0.17.2+1 # +1 since we haven't actually published this yet
 
@@ -57,6 +57,7 @@ flutter:
 flutter_launcher_icons:
   android: "launcher_icon"
   ios: true
+  remove_alpha_ios: true
   image_path: "assets/images/icon.png"
   web:
     generate: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: defend_your_flame
 description: Defend your flame from the enemy
 publish_to: 'none'
-version: 0.17.2+1 # +1 since we haven't actually published this yet
+version: 0.17.3+1 # +1 since we haven't actually published this yet
 
 environment:
   sdk: '>=3.1.2 <4.0.0'


### PR DESCRIPTION
Lots of small changes, from the changelog:

```
## 0.17.3 - 16th May, 2024

### New Features
- N/A

### Bug Fixes
- N/A

### Improvements / Balances
- Shifted the collision detection damage for the wall to be the segment of the wall the entity corresponds with, rather than the entire bounding polygon
- Adjusted gravity (increased by approx 10%), and increased air friction by 10% also
- Slowed down slightly the first boss
- Entities that are attacking the wall on top now fall after it's destroyed

```

Also started scaffolding changes to the shop, each purchase has an enum now, this should make future shop changes easier.