### PR TITLE
More balances to the 0.18.1 change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.18.1 - 17th May, 2024
+
+### New Features
+- N/A
+
+### Bug Fixes
+- Fixed health text showing "-" instead of "+"
+- Killing entities on the game over screen no longer shows "+" gold text
+- Fixed the drag state (red tint) not resetting in some cases
+
+### Improvements / Balances
+- Small improvements to the spawning logic
+ - Duration of round spawning scales a bit less into later rounds (as in, lower duration)
+ - Slightly higher number of weak entities into later rounds
+ - Changed the boss fight at round 25 to have only one death reaper instead of 2, along with the firebeast
+- Made the fire beast slightly slower
+- Made entity idle timer "reset" after being thrown, so they don't suddenly idle again after landing
+- Made rock golems approximately 5% larger
+- Renamed the blacksmith to "Henry The Elder" as per feedback from a friend
+
+
 ## 0.18.0 - 17th May, 2024
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@
 - Made rock golems approximately 5% larger
 - Renamed the blacksmith to "Henry The Elder" as per feedback from a friend
 
-
 ## 0.18.0 - 17th May, 2024
 
 ### New Features

--- a/lib/constants/entity_spawn_constants.dart
+++ b/lib/constants/entity_spawn_constants.dart
@@ -19,8 +19,8 @@ class EntitySpawnConstants {
     10: [DeathReaper],
     15: [DeathReaper, DeathReaper],
     20: [FireBeast],
-    25: [DeathReaper, FireBeast, DeathReaper],
-    30: [FireBeast, FireBeast, FireBeast],
+    25: [DeathReaper, FireBeast],
+    30: [FireBeast, FireBeast],
   };
 
   static const Set<Type> weakGroundMobs = {Slime, Skeleton};

--- a/lib/constants/translations/app_string_data.dart
+++ b/lib/constants/translations/app_string_data.dart
@@ -77,7 +77,7 @@ class AppStringData {
       ]),
       'attackTotemQuote': '"The best defense is a good offense."',
 
-      'blacksmithName': 'Blacksmith',
+      'blacksmithName': 'Henry The Elder',
       'blacksmithDescription': AppStringHelper.purchasableDescription(attributes: [
         "Repairs ${AppStrings.placeholderText}% of your wall health per round",
         "Repair happens at the end of the round",

--- a/lib/constants/versioning_constants.dart
+++ b/lib/constants/versioning_constants.dart
@@ -9,7 +9,7 @@ class VersioningConstants {
 
   static const _majorVersion = 0;
   static const _minorVersion = 18;
-  static const _patchVersion = 0;
+  static const _patchVersion = 1;
 
   static const _releaseVersion = ReleaseVersion.alpha;
 

--- a/lib/core/flame/components/effects/text/health_text.dart
+++ b/lib/core/flame/components/effects/text/health_text.dart
@@ -10,10 +10,10 @@ class HealthText extends FloatingText {
   static final TextRenderer _damageTextRenderer = TextManager.customDefaultRenderer(fontSize: 13, color: Colors.green);
   HealthText(int health) : super(textRenderer: _damageTextRenderer) {
     scale = Vector2.all(_scaleHealthText(health));
-    text = "-$health";
+    text = "+$health";
   }
 
   double _scaleHealthText(int health) {
-    return 1 + (sqrt(health) / 4);
+    return 1 + (sqrt(health) / 3);
   }
 }

--- a/lib/core/flame/components/entities/draggable_entity.dart
+++ b/lib/core/flame/components/entities/draggable_entity.dart
@@ -112,6 +112,12 @@ class DraggableEntity extends Entity with DragCallbacks, HoverCallbacks, WallAsS
     _attemptToBeginDragging();
   }
 
+  @override
+  void onTapCancel(TapCancelEvent event) {
+    stopDragging();
+    super.onTapCancel(event);
+  }
+
   // A limitation within Flame draggable callback is that it won't register a start of drag on click, but instead, on drag.
   // This is a workaround to make sure that the drag starts on click.
   @override

--- a/lib/core/flame/components/entities/entity.dart
+++ b/lib/core/flame/components/entities/entity.dart
@@ -204,7 +204,10 @@ class Entity extends BaseEntity
 
       // Apply the bounding constraints to make sure the entity is in the correct position.
       _applyBoundingConstraints(0);
-      world.playerBase.mutateGold(entityConfig.goldOnKill, position: trueCenter);
+
+      if (!world.worldStateManager.gameOver) {
+        world.playerBase.mutateGold(entityConfig.goldOnKill, position: trueCenter);
+      }
 
       for (var hitbox in _hitboxes) {
         hitbox.collisionType = CollisionType.inactive;

--- a/lib/core/flame/components/entities/mixins/has_idle_time.dart
+++ b/lib/core/flame/components/entities/mixins/has_idle_time.dart
@@ -61,6 +61,11 @@ mixin HasIdleTime on Entity {
       } else if (current == EntityState.idle && _idleTimer >= _timeToSpendIdleInSeconds) {
         toggleToWalking();
       }
+
+      // If they were picked up and dropped, we should reset this.
+      if (current == EntityState.falling) {
+        forceResetIdleTimer();
+      }
     }
 
     super.update(dt);

--- a/lib/core/flame/components/entities/mobs/bosses/fire_beast.dart
+++ b/lib/core/flame/components/entities/mobs/bosses/fire_beast.dart
@@ -19,7 +19,7 @@ class FireBeast extends Entity with HasDraggableCollisions {
       frames: 6,
     ),
     walkingConfig: AnimationConfig(
-      stepTime: 0.129,
+      stepTime: 0.12,
       frames: 12,
     ),
     attackingConfig: AnimationConfig(
@@ -30,7 +30,7 @@ class FireBeast extends Entity with HasDraggableCollisions {
       stepTime: 0.12,
       frames: 22,
     ),
-    baseWalkingSpeed: 14,
+    baseWalkingSpeed: 13,
     damageOnAttack: 30,
     goldOnKill: 100,
     totalHealth: DamageConstants.fallDamage * 50,

--- a/lib/core/flame/components/entities/mobs/rock_golem.dart
+++ b/lib/core/flame/components/entities/mobs/rock_golem.dart
@@ -14,7 +14,7 @@ class RockGolem extends DraggableEntity with HasIdleTime {
   static final EntityConfig _rockGolemConfig = EntityConfig(
     entityResourceName: 'rock_golem',
     defaultSize: Vector2(90, 64),
-    defaultScale: 1.45,
+    defaultScale: 1.5,
     walkingConfig: AnimationConfig(frames: 10, stepTime: 0.16),
     attackingConfig: AnimationConfig(frames: 11, stepTime: 0.14),
     dragConfig: AnimationConfig(frames: 8, stepTime: 0.16),

--- a/lib/core/flame/components/hud/game_selection_hud.dart
+++ b/lib/core/flame/components/hud/game_selection_hud.dart
@@ -13,10 +13,10 @@ class GameSelectionHud extends BasicHud {
   late final StartGameButton _startGame = StartGameButton()
     ..position = Vector2(world.worldWidth / 2, world.worldHeight / 3);
 
-  late final FastTrackToButton _fastTrackToTen = FastTrackToButton(round: 10, gold: 460)
+  late final FastTrackToButton _fastTrackToTen = FastTrackToButton(round: 10, gold: 480)
     ..position = _startGame.position + ThemingConstants.menuButtonGap;
 
-  late final FastTrackToButton _fastTrackToFifteen = FastTrackToButton(round: 15, gold: 900)
+  late final FastTrackToButton _fastTrackToFifteen = FastTrackToButton(round: 15, gold: 1000)
     ..position = _fastTrackToTen.position + ThemingConstants.menuButtonGap;
 
   late final LoadGameButton _loadGame = LoadGameButton()

--- a/lib/core/flame/helpers/entity_spawn_helper.dart
+++ b/lib/core/flame/helpers/entity_spawn_helper.dart
@@ -94,11 +94,11 @@ class EntitySpawnHelper {
     var startPosition = _randomGroundSpawnPosition(worldHeight: worldHeight);
     var speedFactor = _randomWalkingSpeedFactor(currentRound: currentRound);
     var randomNumber = GlobalVars.rand.nextInt(100);
+    var wolfLuck = _tapper(currentRound.toDouble() * 2, tapperLess: true);
 
-    if (currentRound >= EntitySpawnConstants.minimumRoundForFastGroundEnemies &&
-        randomNumber < _tapper(currentRound.toDouble() * 2)) {
+    if (currentRound >= EntitySpawnConstants.minimumRoundForFastGroundEnemies && randomNumber < wolfLuck) {
       return IceWolf.spawn(position: startPosition, speedFactor: speedFactor);
-    } else if (randomNumber < 70) {
+    } else if (randomNumber < 70 + wolfLuck) {
       return Skeleton.spawn(position: startPosition, speedFactor: speedFactor);
     } else {
       return Slime.spawn(position: startPosition, speedFactor: speedFactor);
@@ -111,7 +111,7 @@ class EntitySpawnHelper {
     var randomNumber = GlobalVars.rand.nextInt(100);
 
     if (currentRound >= EntitySpawnConstants.minimumRoundForRockGolems &&
-        randomNumber < _tapper(currentRound.toDouble() * 3)) {
+        randomNumber < _tapper(currentRound.toDouble() * 3, tapperLess: true)) {
       return RockGolem.spawn(position: startPosition, speedFactor: speedFactor);
     } else {
       return StrongSkeleton.spawn(position: startPosition, speedFactor: speedFactor);
@@ -130,10 +130,10 @@ class EntitySpawnHelper {
   }
 
   static double _secondsToSpawnOver(int currentRound) {
-    return _tapper(currentRound * 12, tapperLess: true).ceil() + 7;
+    return _tapper(currentRound * 10, tapperLess: true).ceil() + 7;
   }
 
-  static int _basicMobsToSpawnThisRound(int currentRound) => _tapper(currentRound * 12).ceil() + 3;
+  static int _basicMobsToSpawnThisRound(int currentRound) => _tapper(currentRound * 12, tapperLess: true).ceil() + 2;
   static int _strongGroundMobsToSpawnThisRound(int currentRound) {
     if (currentRound < EntitySpawnConstants.minimumRoundForStrongGroundEnemies) {
       return 0;

--- a/lib/core/flame/mixins/has_mouse_drag.dart
+++ b/lib/core/flame/mixins/has_mouse_drag.dart
@@ -32,6 +32,13 @@ mixin HasMouseDrag on TapCallbacks, DragCallbacks, HasGameReference<MainGame> {
     resetCursor();
   }
 
+  @override
+  @mustCallSuper
+  void onTapCancel(TapCancelEvent event) {
+    super.onTapCancel(event);
+    resetCursor();
+  }
+
   void setCursor() {
     game.mouseCursor = SystemMouseCursors.grabbing;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: defend_your_flame
 description: Defend your flame from the enemy
 publish_to: 'none'
-version: 0.18.0+1 # +1 since we haven't actually published this yet
+version: 0.18.1+1 # +1 since we haven't actually published this yet
 
 environment:
   sdk: '>=3.1.2 <4.0.0'


### PR DESCRIPTION
After a full playthrough until I died on round 25, here were a bunch of balances I thought were appropriate, from the changelog:

```
## 0.18.1 - 17th May, 2024

### New Features
- N/A

### Bug Fixes
- Fixed health text showing "-" instead of "+"
- Killing entities on the game over screen no longer shows "+" gold text
- Fixed the drag state (red tint) not resetting in some cases

### Improvements / Balances
- Small improvements to the spawning logic
 - Duration of round spawning scales a bit less into later rounds (as in, lower duration)
 - Slightly higher number of weak entities into later rounds
 - Changed the boss fight at round 25 to have only one death reaper instead of 2, along with the firebeast
- Made the fire beast slightly slower
- Made entity idle timer "reset" after being thrown, so they don't suddenly idle again after landing
- Made rock golems approximately 5% larger
- Renamed the blacksmith to "Henry The Elder" as per feedback from a friend
```